### PR TITLE
ci: fix clang tidy failure when no cpp file detected

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,12 +230,12 @@ jobs:
 
       - name: Run clang-tidy
         run: |
-          src_files=$(git diff origin/main --name-only | grep "\.cpp")
+          src_files=$(git diff origin/main --name-only | grep "\.cpp" || true)
           if [ -z "$src_files" ]; then
             echo "No files to check."
-            exit 0
+          else
+            clang-tidy --config-file=./.clang-tidy -p ${{github.workspace}}/build/compile_commands.json -warnings-as-errors='*' $src_files
           fi
-          clang-tidy --config-file=./.clang-tidy  -p ${{github.workspace}}/build/compile_commands.json -warnings-as-errors='*' $src_files
 
   cppcheck:
     needs: build


### PR DESCRIPTION
Ticket: SOUR-110