### PR TITLE
chore: solve warnings out from variadic macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ set(GCOV_VERSION
 #---------------------------------------------------------------------------------------------------------------------------------
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_EXTENSIONS ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)

--- a/cmake/compiler_warnings.cmake
+++ b/cmake/compiler_warnings.cmake
@@ -41,7 +41,6 @@ function(
   set(COMMON_WARNINGS
       -Wall
       -Wextra # reasonable and standard
-      -Wpedantic
       -Wshadow # warn the user if a variable declaration shadows one from a parent context
       -Wnon-virtual-dtor # warn the user if a class with virtual functions has a non-virtual destructor. This helps
       # catch hard to track down memory errors


### PR DESCRIPTION
Warning: ISO C++11 requires at least one argument for the "..." in a variadic macro Because of usage of -Wpedantic and not passing any argument to the variadic macro, the compiler will throw a warning. This commit solves the warning by removing the trailing comma from the variadic macro.

Ticket: SOUR-76