### PR TITLE
src: Migrate from clang 15 to 19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,17 +167,17 @@ jobs:
         shell: bash
 
       - name: Download llvm build cache
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.config.with_cxx == '_build_cxx'
         uses: actions/download-artifact@v4
         with:
-          name: clang-15.0.7-linux
+          name: clang-19.1.7-linux
           path: ${{github.workspace}}/external
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: 13470680180 # TODO(Hussein): Need to be fixed
+          run-id: 13795569336 # TODO(Hussein): Need to be fixed
 
       - name: Install llvm (Ubuntu)
-        if: runner.os == 'Linux'
-        run: tar -xvf ${{github.workspace}}/external/clang-15.0.7-linux.tar.gz -C ${{github.workspace}}/external
+        if: runner.os == 'Linux' && matrix.config.with_cxx == '_build_cxx'
+        run: tar -xvf ${{github.workspace}}/external/clang-19.1.7-linux.tar.gz -C ${{github.workspace}}/external
 
       - name: Configure CMake (Ubuntu)
         if: runner.os == 'Linux'

--- a/.github/workflows/clang_build.yml
+++ b/.github/workflows/clang_build.yml
@@ -6,48 +6,37 @@ on:
       clang_version:
         description: 'Clang version to build'
         required: false
-        default: '15.0.7'
+        default: '19.1.7'
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
 
 env:
-  CLANG_VERSION: ${{ github.event.inputs.clang_version || '15.0.7' }}
+  CLANG_VERSION: ${{ github.event.inputs.clang_version || '19.1.7' }}
   INSTALL_DIR: ${{ github.workspace }}/clang-install
-  CACHE_KEY: clang-15-build-${{ github.ref_name }}
 
 jobs:
   build-clang:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Install Build Dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            curl \
             cmake \
             ninja-build \
-            python3 \
             gcc \
             g++ \
-            libncurses5-dev \
-            libzip-dev
+            git
 
-      - name: Check Cache
-        id: clang-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.INSTALL_DIR }}
-          key: ${{ env.CACHE_KEY }}-${{ hashFiles('**/CMakeLists.txt') }}
-          restore-keys: |
-            ${{ env.CACHE_KEY }}
-
-      - name: Download LLVM/Clang Source
-        if: steps.clang-cache.outputs.cache-hit != 'true'
+      - name: Clone LLVM project
         run: |
-          curl -o llvmorg-15.0.7.tar.gz https://codeload.github.com/llvm/llvm-project/tar.gz/refs/tags/llvmorg-${CLANG_VERSION}
-          tar -xzf llvmorg-${CLANG_VERSION}.tar.gz
-          mv llvm-project-llvmorg-${CLANG_VERSION} llvm-project
+          git clone https://github.com/llvm/llvm-project.git
+          cd llvm-project
+          git checkout tags/llvmorg-${CLANG_VERSION}
 
       - name: Configure CMake
-        if: steps.clang-cache.outputs.cache-hit != 'true'
         working-directory: llvm-project
         run: |
           cmake -S llvm -B build \
@@ -61,19 +50,16 @@ jobs:
             -DLLVM_TARGETS_TO_BUILD=host
 
       - name: Build Clang
-        if: steps.clang-cache.outputs.cache-hit != 'true'
         working-directory: llvm-project/build
         run: |
           ninja
 
       - name: Install Clang
-        if: steps.clang-cache.outputs.cache-hit != 'true'
         working-directory: llvm-project/build
         run: |
           ninja install
 
       - name: Compress Clang Installation
-        if: steps.clang-cache.outputs.cache-hit != 'true'
         run: |
           tar -czvf clang-${CLANG_VERSION}-linux.tar.gz -C ${{ env.INSTALL_DIR }} .
 
@@ -86,4 +72,3 @@ jobs:
       - name: Cleanup
         run: |
           rm -rf llvm-project
-          rm llvmorg-${CLANG_VERSION}.tar.gz

--- a/.github/workflows/clang_build.yml
+++ b/.github/workflows/clang_build.yml
@@ -7,10 +7,6 @@ on:
         description: 'Clang version to build'
         required: false
         default: '19.1.7'
-  push:
-    branches: ["main"]
-  pull_request:
-    branches: ["main"]
 
 env:
   CLANG_VERSION: ${{ github.event.inputs.clang_version || '19.1.7' }}

--- a/src/core/utility/utility/utility.cpp
+++ b/src/core/utility/utility/utility.cpp
@@ -4,14 +4,15 @@
 #include <range/v3/view/transform.hpp>
 
 size_t utility::digits(size_t n) {
+  constexpr int DigitCount = 10;
   int digits = 1;
 
-  while(n >= 10) {
-    n /= 10;
+  while(n >= DigitCount) {
+    n /= DigitCount;
     digits++;
   }
 
-  return digits;
+  return static_cast<size_t>(digits);
 }
 
 namespace utility {

--- a/src/core/utility/utility/utility.h
+++ b/src/core/utility/utility/utility.h
@@ -1,5 +1,4 @@
 #pragma once
-// STL
 #include <algorithm>
 #include <cstdarg>
 #include <deque>
@@ -82,7 +81,7 @@ template <>
 std::vector<std::string> toStrings(const std::vector<FilePath>& d);
 
 std::vector<std::filesystem::path> toStlPath(const std::vector<FilePath>& oldPaths);
-std::vector<FilePath> toFilePath(const std::vector<std::filesystem::path>& d);
+std::vector<FilePath> toFilePath(const std::vector<std::filesystem::path>& oldPaths);
 
 template <typename T>
 std::vector<std::wstring> toWStrings(const std::vector<T>& d);

--- a/src/lib/settings/source_group/component/cxx/SourceGroupSettingsWithCppStandard.cpp
+++ b/src/lib/settings/source_group/component/cxx/SourceGroupSettingsWithCppStandard.cpp
@@ -1,6 +1,6 @@
 #include "SourceGroupSettingsWithCppStandard.h"
 
-#include "ProjectSettings.h"
+#include "ConfigManager.hpp"
 
 std::wstring SourceGroupSettingsWithCppStandard::getDefaultCppStandardStatic() {
 #ifdef __linux__
@@ -9,6 +9,8 @@ std::wstring SourceGroupSettingsWithCppStandard::getDefaultCppStandardStatic() {
   return L"c++17";
 #endif
 }
+
+SourceGroupSettingsWithCppStandard::~SourceGroupSettingsWithCppStandard() = default;
 
 std::wstring SourceGroupSettingsWithCppStandard::getCppStandard() const {
   if(m_cppStandard.empty()) {
@@ -21,27 +23,27 @@ void SourceGroupSettingsWithCppStandard::setCppStandard(const std::wstring& stan
   m_cppStandard = standard;
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::vector<std::wstring> SourceGroupSettingsWithCppStandard::getAvailableCppStandards() const {
   // as defined in clang/include/clang/Frontend/LangStandards.def
 
-  return {L"c++2a",
-          L"gnu++2a",
-          L"c++17",
-          L"gnu++17",
-          L"c++14",
-          L"gnu++14",
-          L"c++11",
-          L"gnu++11",
-          L"c++03",
-          L"gnu++03",
-          L"c++98",
-          L"gnu++98"};
+  // clang-format off
+  return {
+  L"c++23", L"gnu++23",
+  L"c++2c", L"gnu++2c",
+  L"c++20", L"gnu++20",
+  L"c++17", L"gnu++17",
+  L"c++14", L"gnu++14",
+  L"c++11", L"gnu++11",
+  L"c++03", L"gnu++03",
+  L"c++98", L"gnu++98"};
+  // clang-format on
 }
 
 bool SourceGroupSettingsWithCppStandard::equals(const SourceGroupSettingsBase* other) const {
-  const SourceGroupSettingsWithCppStandard* otherPtr = dynamic_cast<const SourceGroupSettingsWithCppStandard*>(other);
+  const auto* otherPtr = dynamic_cast<const SourceGroupSettingsWithCppStandard*>(other);
 
-  return (otherPtr && m_cppStandard == otherPtr->m_cppStandard);
+  return (nullptr != otherPtr && m_cppStandard == otherPtr->m_cppStandard);
 }
 
 void SourceGroupSettingsWithCppStandard::load(const ConfigManager* config, const std::string& key) {
@@ -52,6 +54,7 @@ void SourceGroupSettingsWithCppStandard::save(ConfigManager* config, const std::
   config->setValue(key + "/cpp_standard", getCppStandard());
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::wstring SourceGroupSettingsWithCppStandard::getDefaultCppStandard() const {
   return getDefaultCppStandardStatic();
 }

--- a/src/lib/settings/source_group/component/cxx/SourceGroupSettingsWithCppStandard.h
+++ b/src/lib/settings/source_group/component/cxx/SourceGroupSettingsWithCppStandard.h
@@ -1,6 +1,4 @@
-#ifndef SOURCE_GROUP_SETTINGS_WITH_CPP_STANDARD_H
-#define SOURCE_GROUP_SETTINGS_WITH_CPP_STANDARD_H
-
+#pragma once
 #include <vector>
 
 #include "SourceGroupSettingsComponent.h"
@@ -9,23 +7,21 @@ class SourceGroupSettingsWithCppStandard : public SourceGroupSettingsComponent {
 public:
   static std::wstring getDefaultCppStandardStatic();
 
-  virtual ~SourceGroupSettingsWithCppStandard() = default;
+  ~SourceGroupSettingsWithCppStandard() override;
 
-  std::wstring getCppStandard() const;
+  [[nodiscard]] std::wstring getCppStandard() const;
   void setCppStandard(const std::wstring& standard);
 
-  std::vector<std::wstring> getAvailableCppStandards() const;
+  [[nodiscard]] std::vector<std::wstring> getAvailableCppStandards() const;
 
 protected:
-  bool equals(const SourceGroupSettingsBase* other) const override;
+  [[nodiscard]] bool equals(const SourceGroupSettingsBase* other) const override;
 
   void load(const ConfigManager* config, const std::string& key) override;
   void save(ConfigManager* config, const std::string& key) override;
 
 private:
-  std::wstring getDefaultCppStandard() const;
+  [[nodiscard]] std::wstring getDefaultCppStandard() const;
 
   std::wstring m_cppStandard;
 };
-
-#endif    // SOURCE_GROUP_SETTINGS_WITH_CPP_STANDARD_H

--- a/src/lib/tests/helper/testStorage/TestStorage.h
+++ b/src/lib/tests/helper/testStorage/TestStorage.h
@@ -6,7 +6,7 @@
 
 class FilePath;
 class Storage;
-class StorageSourceLocation;
+struct StorageSourceLocation;
 
 class TestStorage {
 public:

--- a/src/lib_cxx/data/parser/cxx/CanonicalFilePathCache.cpp
+++ b/src/lib_cxx/data/parser/cxx/CanonicalFilePathCache.cpp
@@ -24,7 +24,7 @@ std::wstring getFileNameOfFileEntry(const clang::FileEntry* entry, const clang::
   }
   return fileName;
 }
-}
+}    // namespace
 #endif
 
 CanonicalFilePathCache::CanonicalFilePathCache(std::shared_ptr<FileRegister> fileRegister) : m_fileRegister(fileRegister) {}

--- a/src/lib_cxx/data/parser/cxx/CanonicalFilePathCache.cpp
+++ b/src/lib_cxx/data/parser/cxx/CanonicalFilePathCache.cpp
@@ -2,9 +2,30 @@
 
 #include <clang/AST/ASTContext.h>
 #include <clang/Basic/FileManager.h>
+#include <clang/Basic/Version.h>
 
 #include "utilityClang.h"
 #include "utilityString.h"
+
+#if CLANG_VERSION_MAJOR > 15
+namespace {
+std::wstring getFileNameOfFileEntry(const clang::FileEntry* entry, const clang::FileEntryRef& fileEntryRef) {
+  std::wstring fileName = L"";
+  if(entry != nullptr) {
+    fileName = utility::decodeFromUtf8(entry->tryGetRealPathName().str());
+    if(fileName.empty()) {
+      fileName = utility::decodeFromUtf8(fileEntryRef.getName().str());
+    } else {
+      fileName = FilePath(utility::decodeFromUtf8(fileEntryRef.getName().str()))
+                     .getParentDirectory()
+                     .concatenate(FilePath(fileName).fileName())
+                     .wstr();
+    }
+  }
+  return fileName;
+}
+}
+#endif
 
 CanonicalFilePathCache::CanonicalFilePathCache(std::shared_ptr<FileRegister> fileRegister) : m_fileRegister(fileRegister) {}
 
@@ -26,7 +47,12 @@ FilePath CanonicalFilePathCache::getCanonicalFilePath(const clang::FileID& fileI
 
   const clang::FileEntry* fileEntry = sourceManager.getFileEntryForID(fileId);
   if(fileEntry != nullptr) {
+#if CLANG_VERSION_MAJOR > 15
+    clang::OptionalFileEntryRef fileEntryRef = sourceManager.getFileEntryRefForID(fileId);
+    filePath = getCanonicalFilePath(getFileNameOfFileEntry(fileEntry, *fileEntryRef));
+#else
     filePath = getCanonicalFilePath(fileEntry);
+#endif
     m_fileIdMap.emplace(fileId, filePath);
   }
 

--- a/src/lib_cxx/data/parser/cxx/CxxAstVisitor.h
+++ b/src/lib_cxx/data/parser/cxx/CxxAstVisitor.h
@@ -1,9 +1,8 @@
 #pragma once
-// STL
 #include <memory>
-// clang
+
 #include <clang/AST/RecursiveASTVisitor.h>
-// internal
+
 #include "CxxAstVisitorComponentBraceRecorder.h"
 #include "CxxAstVisitorComponentContext.h"
 #include "CxxAstVisitorComponentDeclRefKind.h"

--- a/src/lib_cxx/data/parser/cxx/CxxAstVisitorComponentBraceRecorder.cpp
+++ b/src/lib_cxx/data/parser/cxx/CxxAstVisitorComponentBraceRecorder.cpp
@@ -1,7 +1,7 @@
 #include "CxxAstVisitorComponentBraceRecorder.h"
 
-#include <clang/Lex/Preprocessor.h>
 #include <clang/Basic/Version.h>
+#include <clang/Lex/Preprocessor.h>
 
 #include "CanonicalFilePathCache.h"
 #include "CxxAstVisitor.h"

--- a/src/lib_cxx/data/parser/cxx/CxxAstVisitorComponentBraceRecorder.cpp
+++ b/src/lib_cxx/data/parser/cxx/CxxAstVisitorComponentBraceRecorder.cpp
@@ -1,6 +1,7 @@
 #include "CxxAstVisitorComponentBraceRecorder.h"
 
 #include <clang/Lex/Preprocessor.h>
+#include <clang/Basic/Version.h>
 
 #include "CanonicalFilePathCache.h"
 #include "CxxAstVisitor.h"
@@ -110,6 +111,17 @@ clang::SourceLocation CxxAstVisitorComponentBraceRecorder::getFirstLBraceLocatio
   }
 
   while(true) {
+#if CLANG_VERSION_MAJOR > 15
+    std::optional<clang::Token> token = clang::Lexer::findNextToken(searchStartLoc, sm, opts);
+    if(token.has_value()) {
+      if(token.value().getKind() == clang::tok::l_brace) {
+        return token.value().getLocation();
+      }
+      searchStartLoc = token.value().getLocation();
+    } else {
+      break;
+    }
+#else
     llvm::Optional<clang::Token> token = clang::Lexer::findNextToken(searchStartLoc, sm, opts);
     if(token.hasValue()) {
       if(token.getValue().getKind() == clang::tok::l_brace) {
@@ -119,7 +131,7 @@ clang::SourceLocation CxxAstVisitorComponentBraceRecorder::getFirstLBraceLocatio
     } else {
       break;
     }
-
+#endif
     if(searchEndLoc < searchStartLoc) {
       break;
     }
@@ -137,11 +149,19 @@ clang::SourceLocation CxxAstVisitorComponentBraceRecorder::getLastRBraceLocation
 
   {
     searchEndLoc = searchEndLoc.getLocWithOffset(-1);
+#if CLANG_VERSION_MAJOR > 15
+    std::optional<clang::Token> token = clang::Lexer::findNextToken(searchEndLoc, sm, opts);
+    if(token.has_value() && token.value().getKind() == clang::tok::r_brace) {
+      return token.value().getLocation();
+    }
+  }
+#else
     llvm::Optional<clang::Token> token = clang::Lexer::findNextToken(searchEndLoc, sm, opts);
     if(token.hasValue() && token.getValue().getKind() == clang::tok::r_brace) {
       return token.getValue().getLocation();
     }
   }
+#endif
 
   while(true) {
     clang::Token token;

--- a/src/lib_cxx/data/parser/cxx/PreprocessorCallbacks.cpp
+++ b/src/lib_cxx/data/parser/cxx/PreprocessorCallbacks.cpp
@@ -38,6 +38,19 @@ void PreprocessorCallbacks::FileChanged(clang::SourceLocation location,
   }
 }
 
+#if CLANG_VERSION_MAJOR > 15
+void PreprocessorCallbacks::InclusionDirective(clang::SourceLocation /*hashLocation*/,
+                        const clang::Token& /*includeToken*/,
+                        llvm::StringRef /*fileName*/,
+                        bool /*isAngled*/,
+                        clang::CharSourceRange fileNameRange,
+                        clang::OptionalFileEntryRef fileEntry,
+                        llvm::StringRef /*searchPath*/,
+                        llvm::StringRef /*relativePath*/,
+                        const clang::Module* /*imported*/,
+                        bool /*ModuleImported*/,
+                        clang::SrcMgr::CharacteristicKind /*fileType*/) {
+#else
 void PreprocessorCallbacks::InclusionDirective(clang::SourceLocation /*hashLocation*/,
                                                const clang::Token& /*includeToken*/,
                                                llvm::StringRef /*fileName*/,
@@ -48,15 +61,16 @@ void PreprocessorCallbacks::InclusionDirective(clang::SourceLocation /*hashLocat
                                                llvm::StringRef /*relativePath*/,
                                                const clang::Module* /*imported*/,
                                                clang::SrcMgr::CharacteristicKind /*fileType*/) {
-  if(m_currentFileSymbolId && fileEntry) {
-    const FilePath includedFilePath = m_canonicalFilePathCache->getCanonicalFilePath(fileEntry.value());
-    const NameHierarchy includedFileNameHierarchy(includedFilePath.wstr(), NAME_DELIMITER_FILE);
+#endif
+if(m_currentFileSymbolId && fileEntry) {
+  const FilePath includedFilePath = m_canonicalFilePathCache->getCanonicalFilePath(fileEntry.value());
+  const NameHierarchy includedFileNameHierarchy(includedFilePath.wstr(), NAME_DELIMITER_FILE);
 
-    Id includedFileSymbolId = m_client->recordSymbol(includedFileNameHierarchy);
+  Id includedFileSymbolId = m_client->recordSymbol(includedFileNameHierarchy);
 
-    m_client->recordReference(
-        REFERENCE_INCLUDE, includedFileSymbolId, m_currentFileSymbolId, getParseLocation(fileNameRange.getAsRange()));
-  }
+  m_client->recordReference(
+      REFERENCE_INCLUDE, includedFileSymbolId, m_currentFileSymbolId, getParseLocation(fileNameRange.getAsRange()));
+}
 }
 
 void PreprocessorCallbacks::MacroDefined(const clang::Token& macroNameToken, const clang::MacroDirective* macroDirective) {

--- a/src/lib_cxx/data/parser/cxx/PreprocessorCallbacks.cpp
+++ b/src/lib_cxx/data/parser/cxx/PreprocessorCallbacks.cpp
@@ -40,16 +40,16 @@ void PreprocessorCallbacks::FileChanged(clang::SourceLocation location,
 
 #if CLANG_VERSION_MAJOR > 15
 void PreprocessorCallbacks::InclusionDirective(clang::SourceLocation /*hashLocation*/,
-                        const clang::Token& /*includeToken*/,
-                        llvm::StringRef /*fileName*/,
-                        bool /*isAngled*/,
-                        clang::CharSourceRange fileNameRange,
-                        clang::OptionalFileEntryRef fileEntry,
-                        llvm::StringRef /*searchPath*/,
-                        llvm::StringRef /*relativePath*/,
-                        const clang::Module* /*imported*/,
-                        bool /*ModuleImported*/,
-                        clang::SrcMgr::CharacteristicKind /*fileType*/) {
+                                               const clang::Token& /*includeToken*/,
+                                               llvm::StringRef /*fileName*/,
+                                               bool /*isAngled*/,
+                                               clang::CharSourceRange fileNameRange,
+                                               clang::OptionalFileEntryRef fileEntry,
+                                               llvm::StringRef /*searchPath*/,
+                                               llvm::StringRef /*relativePath*/,
+                                               const clang::Module* /*imported*/,
+                                               bool /*ModuleImported*/,
+                                               clang::SrcMgr::CharacteristicKind /*fileType*/) {
 #else
 void PreprocessorCallbacks::InclusionDirective(clang::SourceLocation /*hashLocation*/,
                                                const clang::Token& /*includeToken*/,
@@ -62,15 +62,15 @@ void PreprocessorCallbacks::InclusionDirective(clang::SourceLocation /*hashLocat
                                                const clang::Module* /*imported*/,
                                                clang::SrcMgr::CharacteristicKind /*fileType*/) {
 #endif
-if(m_currentFileSymbolId && fileEntry) {
-  const FilePath includedFilePath = m_canonicalFilePathCache->getCanonicalFilePath(fileEntry.value());
-  const NameHierarchy includedFileNameHierarchy(includedFilePath.wstr(), NAME_DELIMITER_FILE);
+  if(m_currentFileSymbolId && fileEntry) {
+    const FilePath includedFilePath = m_canonicalFilePathCache->getCanonicalFilePath(fileEntry.value());
+    const NameHierarchy includedFileNameHierarchy(includedFilePath.wstr(), NAME_DELIMITER_FILE);
 
-  Id includedFileSymbolId = m_client->recordSymbol(includedFileNameHierarchy);
+    Id includedFileSymbolId = m_client->recordSymbol(includedFileNameHierarchy);
 
-  m_client->recordReference(
-      REFERENCE_INCLUDE, includedFileSymbolId, m_currentFileSymbolId, getParseLocation(fileNameRange.getAsRange()));
-}
+    m_client->recordReference(
+        REFERENCE_INCLUDE, includedFileSymbolId, m_currentFileSymbolId, getParseLocation(fileNameRange.getAsRange()));
+  }
 }
 
 void PreprocessorCallbacks::MacroDefined(const clang::Token& macroNameToken, const clang::MacroDirective* macroDirective) {

--- a/src/lib_cxx/data/parser/cxx/PreprocessorCallbacks.h
+++ b/src/lib_cxx/data/parser/cxx/PreprocessorCallbacks.h
@@ -5,6 +5,7 @@
 #include <set>
 
 #include <clang/Basic/SourceManager.h>
+#include <clang/Basic/Version.h>
 #include <clang/Lex/MacroInfo.h>
 #include <clang/Lex/PPCallbacks.h>
 #include <clang/Lex/Token.h>
@@ -25,6 +26,19 @@ public:
 
   void FileChanged(clang::SourceLocation location, FileChangeReason reason, clang::SrcMgr::CharacteristicKind, clang::FileID) override;
 
+#if CLANG_VERSION_MAJOR >= 19
+  void InclusionDirective(clang::SourceLocation HashLoc,
+                          const clang::Token& IncludeTok,
+                          llvm::StringRef FileName,
+                          bool IsAngled,
+                          clang::CharSourceRange FilenameRange,
+                          clang::OptionalFileEntryRef File,
+                          llvm::StringRef SearchPath,
+                          llvm::StringRef RelativePath,
+                          const clang::Module* SuggestedModule,
+                          bool ModuleImported,
+                          clang::SrcMgr::CharacteristicKind FileType) override;
+#else
   void InclusionDirective(clang::SourceLocation hashLocation,
                           const clang::Token& includeToken,
                           llvm::StringRef fileName,
@@ -35,6 +49,7 @@ public:
                           llvm::StringRef relativePath,
                           const clang::Module* imported,
                           clang::SrcMgr::CharacteristicKind fileType) override;
+#endif
 
   void MacroDefined(const clang::Token& macroNameToken, const clang::MacroDirective* macroDirective) override;
   void MacroUndefined(const clang::Token& macroNameToken,

--- a/src/lib_cxx/data/parser/cxx/utilityClang.cpp
+++ b/src/lib_cxx/data/parser/cxx/utilityClang.cpp
@@ -4,8 +4,8 @@
 #include <clang/AST/DeclCXX.h>
 #include <clang/AST/DeclTemplate.h>
 #include <clang/Basic/FileManager.h>
-#include <clang/Lex/Preprocessor.h>
 #include <clang/Basic/Version.h>
+#include <clang/Lex/Preprocessor.h>
 
 #include "CanonicalFilePathCache.h"
 #include "FilePath.h"
@@ -74,7 +74,7 @@ SymbolKind utility::convertTagKind(const clang::TagTypeKind tagKind) {
     return SYMBOL_KIND_MAX;
   }
 #else
-switch(tagKind) {
+  switch(tagKind) {
   case clang::TTK_Struct:
     return SYMBOL_STRUCT;
   case clang::TTK_Union:
@@ -99,8 +99,7 @@ bool utility::isLocalVariable(const clang::VarDecl* d) {
 }
 
 bool utility::isLocalVariable(const clang::ValueDecl* d) {
-  if(!llvm::isa<clang::ParmVarDecl>(d) &&
-     !(d->getParentFunctionOrMethod() == nullptr)) {
+  if(!llvm::isa<clang::ParmVarDecl>(d) && !(d->getParentFunctionOrMethod() == nullptr)) {
     return true;
   }
   return false;
@@ -134,10 +133,7 @@ std::wstring utility::getFileNameOfFileEntry(const clang::FileEntry* entry) {
     fileName = utility::decodeFromUtf8(entry->tryGetRealPathName().str());
 #if CLANG_VERSION_MAJOR > 15
     if(!fileName.empty()) {
-      fileName = FilePath{fileName}
-                     .getParentDirectory()
-                     .concatenate(FilePath(fileName).fileName())
-                     .wstr();
+      fileName = FilePath{fileName}.getParentDirectory().concatenate(FilePath(fileName).fileName()).wstr();
     }
 #else
     if(fileName.empty()) {

--- a/src/lib_cxx/data/parser/cxx/utilityClang.h
+++ b/src/lib_cxx/data/parser/cxx/utilityClang.h
@@ -23,7 +23,9 @@ bool isImplicit(const clang::Decl* d);
 AccessKind convertAccessSpecifier(clang::AccessSpecifier access);
 SymbolKind convertTagKind(const clang::TagTypeKind tagKind);
 bool isLocalVariable(const clang::VarDecl* d);
+bool isLocalVariable(const clang::ValueDecl* d);
 bool isParameter(const clang::VarDecl* d);
+bool isParameter(const clang::ValueDecl* d);
 SymbolKind getSymbolKind(const clang::VarDecl* d);
 std::wstring getFileNameOfFileEntry(const clang::FileEntry* entry);
 

--- a/tests/integration/lib_cxx/CxxParserTestSuite.cpp
+++ b/tests/integration/lib_cxx/CxxParserTestSuite.cpp
@@ -5,7 +5,6 @@
 
 #include "../../../src/lib/tests/mocks/MockedApplicationSetting.hpp"
 #include "CxxParser.h"
-#include "gmock/gmock.h"
 #include "IndexerCommandCxx.h"
 #include "IndexerStateInfo.h"
 #include "language_packages.h"
@@ -46,61 +45,61 @@ struct CxxParserTestSuite : testing::Test {
   std::shared_ptr<MockedApplicationSettings> mMocked = std::make_shared<MockedApplicationSettings>();
 };
 
-TEST_F(CxxParserTestSuite, cxxParserFindsGlobalVariableDeclaration) {
+TEST_F(CxxParserTestSuite, FindsGlobalVariableDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode("int x;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->globalVariables, L"int x <1:5 1:5>"));
+  EXPECT_THAT(client->globalVariables, testing::Contains(L"int x <1:5 1:5>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsStaticGlobalVariableDeclaration) {
+TEST_F(CxxParserTestSuite, FindsStaticGlobalVariableDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode("static int x;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->globalVariables, L"int x (temp.cpp) <1:12 1:12>"));
+  EXPECT_THAT(client->globalVariables, testing::Contains(L"int x (temp.cpp) <1:12 1:12>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsStaticConstGlobalVariableDeclaration) {
+TEST_F(CxxParserTestSuite, FindsStaticConstGlobalVariableDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode("static const int x;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->globalVariables, L"const int x (temp.cpp) <1:18 1:18>"));
+  EXPECT_THAT(client->globalVariables, testing::Contains(L"const int x (temp.cpp) <1:18 1:18>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsGlobalClassDefinition) {
+TEST_F(CxxParserTestSuite, FindsGlobalClassDefinition) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A\n"
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->classes, L"A <1:1 <1:7 1:7> 3:1>"));
+  EXPECT_THAT(client->classes, testing::Contains(L"A <1:1 <1:7 1:7> 3:1>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsGlobalClassDeclaration) {
+TEST_F(CxxParserTestSuite, FindsGlobalClassDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode("class A;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->classes, L"A <1:7 1:7>"));
+  EXPECT_THAT(client->classes, testing::Contains(L"A <1:7 1:7>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsGlobalStructDefinition) {
+TEST_F(CxxParserTestSuite, FindsGlobalStructDefinition) {
   std::shared_ptr<TestStorage> client = parseCode(
       "struct A\n"
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->structs, L"A <1:1 <1:8 1:8> 3:1>"));
+  EXPECT_THAT(client->structs, testing::Contains(L"A <1:1 <1:8 1:8> 3:1>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsGlobalStructDeclaration) {
+TEST_F(CxxParserTestSuite, FindsGlobalStructDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode("struct A;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->structs, L"A <1:8 1:8>"));
+  EXPECT_THAT(client->structs, testing::Contains(L"A <1:8 1:8>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsVariableDefinitionsInGlobalScope) {
+TEST_F(CxxParserTestSuite, FindsVariableDefinitionsInGlobalScope) {
   std::shared_ptr<TestStorage> client = parseCode("int x;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->globalVariables, L"int x <1:5 1:5>"));
+  EXPECT_THAT(client->globalVariables, testing::Contains(L"int x <1:5 1:5>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsFieldsInClassWithAccessType) {
+TEST_F(CxxParserTestSuite, FindsFieldsInClassWithAccessType) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A\n"
       "{\n"
@@ -114,13 +113,13 @@ TEST_F(CxxParserTestSuite, cxxParserFindsFieldsInClassWithAccessType) {
       "	const int d;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->fields, L"private int A::a <3:6 3:6>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->fields, L"public int A::b <6:6 6:6>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->fields, L"protected static int A::c <8:13 8:13>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->fields, L"private const int A::d <10:12 10:12>"));
+  EXPECT_THAT(client->fields, testing::Contains(L"private int A::a <3:6 3:6>"));
+  EXPECT_THAT(client->fields, testing::Contains(L"public int A::b <6:6 6:6>"));
+  EXPECT_THAT(client->fields, testing::Contains(L"protected static int A::c <8:13 8:13>"));
+  EXPECT_THAT(client->fields, testing::Contains(L"private const int A::d <10:12 10:12>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsFunctionDeclaration) {
+TEST_F(CxxParserTestSuite, FindsFunctionDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode(
       "int ceil(float a)\n"
       "{\n"
@@ -130,7 +129,7 @@ TEST_F(CxxParserTestSuite, cxxParserFindsFunctionDeclaration) {
   EXPECT_THAT(client->functions, testing::Contains(testing::StrEq(L"int ceil(float) <1:1 <1:1 <1:5 1:8> 1:17> 4:1>")));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsStaticFunctionDeclaration) {
+TEST_F(CxxParserTestSuite, FindsStaticFunctionDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode(
       "static int ceil(float a)\n"
       "{\n"
@@ -141,7 +140,7 @@ TEST_F(CxxParserTestSuite, cxxParserFindsStaticFunctionDeclaration) {
               testing::Contains(testing::StrEq(L"static int ceil(float) (temp.cpp) <1:1 <1:1 <1:12 1:15> 1:24> 4:1>")));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMethodDeclaration) {
+TEST_F(CxxParserTestSuite, FindsMethodDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class B\n"
       "{\n"
@@ -152,7 +151,7 @@ TEST_F(CxxParserTestSuite, cxxParserFindsMethodDeclaration) {
   EXPECT_THAT(client->methods, testing::Contains(testing::StrEq(L"public void B::B() <4:2 <4:2 4:2> 4:4>")));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsOverloadedOperatorDeclaration) {
+TEST_F(CxxParserTestSuite, FindsOverloadedOperatorDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class B\n"
       "{\n"
@@ -160,11 +159,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsOverloadedOperatorDeclaration) {
       "	B& operator=(const B& other);\n"
       "};\n");
 
-  EXPECT_TRUE(
-      utility::containsElement<std::wstring>(client->methods, L"public B & B::operator=(const B &) <4:2 <4:5 4:13> 4:29>"));
+  EXPECT_THAT(client->methods, testing::Contains(L"public B & B::operator=(const B &) <4:2 <4:5 4:13> 4:29>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMethodDeclarationAndDefinition) {
+TEST_F(CxxParserTestSuite, FindsMethodDeclarationAndDefinition) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class B\n"
       "{\n"
@@ -175,10 +173,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsMethodDeclarationAndDefinition) {
       "{\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->methods, L"public void B::B() <6:1 <6:4 6:4> 8:1>"));
+  EXPECT_THAT(client->methods, testing::Contains(L"public void B::B() <6:1 <6:4 6:4> 8:1>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsVirtualMethodDeclaration) {
+TEST_F(CxxParserTestSuite, FindsVirtualMethodDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class B\n"
       "{\n"
@@ -186,10 +184,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsVirtualMethodDeclaration) {
       "	virtual void process();\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->methods, L"public void B::process() <4:2 <4:15 4:21> 4:23>"));
+  EXPECT_THAT(client->methods, testing::Contains(L"public void B::process() <4:2 <4:15 4:21> 4:23>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsPureVirtualMethodDeclaration) {
+TEST_F(CxxParserTestSuite, FindsPureVirtualMethodDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class B\n"
       "{\n"
@@ -197,29 +195,28 @@ TEST_F(CxxParserTestSuite, cxxParserFindsPureVirtualMethodDeclaration) {
       "	virtual void process() = 0;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->methods, L"protected void B::process() <4:2 <4:15 4:21> 4:27>"));
+  EXPECT_THAT(client->methods, testing::Contains(L"protected void B::process() <4:2 <4:15 4:21> 4:27>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNamedNamespaceDeclaration) {
+TEST_F(CxxParserTestSuite, FindsNamedNamespaceDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace A\n"
       "{\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->namespaces, L"A <1:1 <1:11 1:11> 3:1>"));
+  EXPECT_THAT(client->namespaces, testing::Contains(L"A <1:1 <1:11 1:11> 3:1>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsAnonymousNamespaceDeclaration) {
+TEST_F(CxxParserTestSuite, FindsAnonymousNamespaceDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace\n"
       "{\n"
       "}\n");
 
-  EXPECT_TRUE(
-      utility::containsElement<std::wstring>(client->namespaces, L"anonymous namespace (temp.cpp<1:1>) <1:1 <2:1 2:1> 3:1>"));
+  EXPECT_THAT(client->namespaces, testing::Contains(L"anonymous namespace (temp.cpp<1:1>) <1:1 <2:1 2:1> 3:1>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMultipleAnonymousNamespaceDeclarationsAsSameSymbol) {
+TEST_F(CxxParserTestSuite, FindsMultipleAnonymousNamespaceDeclarationsAsSameSymbol) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace\n"
       "{\n"
@@ -228,14 +225,12 @@ TEST_F(CxxParserTestSuite, cxxParserFindsMultipleAnonymousNamespaceDeclarationsA
       "{\n"
       "}\n");
 
-  EXPECT_TRUE(
-      utility::containsElement<std::wstring>(client->namespaces, L"anonymous namespace (temp.cpp<1:1>) <1:1 <2:1 2:1> 3:1>"));
+  EXPECT_THAT(client->namespaces, testing::Contains(L"anonymous namespace (temp.cpp<1:1>) <1:1 <2:1 2:1> 3:1>"));
 
-  EXPECT_TRUE(
-      utility::containsElement<std::wstring>(client->namespaces, L"anonymous namespace (temp.cpp<1:1>) <4:1 <5:1 5:1> 6:1>"));
+  EXPECT_THAT(client->namespaces, testing::Contains(L"anonymous namespace (temp.cpp<1:1>) <4:1 <5:1 5:1> 6:1>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMultipleNestedAnonymousNamespaceDeclarationsAsDifferentSymbol) {
+TEST_F(CxxParserTestSuite, FindsMultipleNestedAnonymousNamespaceDeclarationsAsDifferentSymbol) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace\n"
       "{\n"
@@ -244,16 +239,14 @@ TEST_F(CxxParserTestSuite, cxxParserFindsMultipleNestedAnonymousNamespaceDeclara
       "	}\n"
       "}\n");
 
-  EXPECT_TRUE(
-      utility::containsElement<std::wstring>(client->namespaces, L"anonymous namespace (temp.cpp<1:1>) <1:1 <2:1 2:1> 6:1>"));
+  EXPECT_THAT(client->namespaces, testing::Contains(L"anonymous namespace (temp.cpp<1:1>) <1:1 <2:1 2:1> 6:1>"));
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->namespaces,
-      L"anonymous namespace (temp.cpp<1:1>)::anonymous namespace (temp.cpp<3:2>) <3:2 <4:2 4:2> "
-      L"5:2>"));
+  EXPECT_THAT(client->namespaces,
+              testing::Contains(L"anonymous namespace (temp.cpp<1:1>)::anonymous namespace (temp.cpp<3:2>) <3:2 <4:2 4:2> "
+                                L"5:2>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsAnonymousNamespaceDeclarationsNestedInsideNamespacesWithDifferentNameAsDifferentSymbol) {
+TEST_F(CxxParserTestSuite, FindsAnonymousNamespaceDeclarationsNestedInsideNamespacesWithDifferentNameAsDifferentSymbol) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace a\n"
       "{\n"
@@ -268,18 +261,16 @@ TEST_F(CxxParserTestSuite, cxxParserFindsAnonymousNamespaceDeclarationsNestedIns
       "	}\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->namespaces, L"a <1:1 <1:11 1:11> 6:1>"));
+  EXPECT_THAT(client->namespaces, testing::Contains(L"a <1:1 <1:11 1:11> 6:1>"));
 
-  EXPECT_TRUE(
-      utility::containsElement<std::wstring>(client->namespaces, L"a::anonymous namespace (temp.cpp<3:2>) <3:2 <4:2 4:2> 5:2>"));
+  EXPECT_THAT(client->namespaces, testing::Contains(L"a::anonymous namespace (temp.cpp<3:2>) <3:2 <4:2 4:2> 5:2>"));
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->namespaces, L"b <7:1 <7:11 7:11> 12:1>"));
+  EXPECT_THAT(client->namespaces, testing::Contains(L"b <7:1 <7:11 7:11> 12:1>"));
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->namespaces, L"b::anonymous namespace (temp.cpp<9:2>) <9:2 <10:2 10:2> 11:2>"));
+  EXPECT_THAT(client->namespaces, testing::Contains(L"b::anonymous namespace (temp.cpp<9:2>) <9:2 <10:2 10:2> 11:2>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsAnonymousNamespaceDeclarationsNestedInsideNamespacesWithSameNameAsSameSymbol) {
+TEST_F(CxxParserTestSuite, FindsAnonymousNamespaceDeclarationsNestedInsideNamespacesWithSameNameAsSameSymbol) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace a\n"
       "{\n"
@@ -294,28 +285,26 @@ TEST_F(CxxParserTestSuite, cxxParserFindsAnonymousNamespaceDeclarationsNestedIns
       "	}\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->namespaces, L"a <1:1 <1:11 1:11> 6:1>"));
+  EXPECT_THAT(client->namespaces, testing::Contains(L"a <1:1 <1:11 1:11> 6:1>"));
 
-  EXPECT_TRUE(
-      utility::containsElement<std::wstring>(client->namespaces, L"a::anonymous namespace (temp.cpp<3:2>) <3:2 <4:2 4:2> 5:2>"));
+  EXPECT_THAT(client->namespaces, testing::Contains(L"a::anonymous namespace (temp.cpp<3:2>) <3:2 <4:2 4:2> 5:2>"));
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->namespaces, L"a <7:1 <7:11 7:11> 12:1>"));
+  EXPECT_THAT(client->namespaces, testing::Contains(L"a <7:1 <7:11 7:11> 12:1>"));
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->namespaces, L"a::anonymous namespace (temp.cpp<3:2>) <9:2 <10:2 10:2> 11:2>"));
+  EXPECT_THAT(client->namespaces, testing::Contains(L"a::anonymous namespace (temp.cpp<3:2>) <9:2 <10:2 10:2> 11:2>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsAnonymousStructDeclaration) {
+TEST_F(CxxParserTestSuite, FindsAnonymousStructDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode(
       "typedef struct\n"
       "{\n"
       "	int x;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->structs, L"anonymous struct (temp.cpp<1:9>) <1:9 <1:9 1:14> 4:1>"));
+  EXPECT_THAT(client->structs, testing::Contains(L"anonymous struct (temp.cpp<1:9>) <1:9 <1:9 1:14> 4:1>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMultipleAnonymousStructDeclarationsAsDistinctElements) {
+TEST_F(CxxParserTestSuite, FindsMultipleAnonymousStructDeclarationsAsDistinctElements) {
   std::shared_ptr<TestStorage> client = parseCode(
       "typedef struct\n"
       "{\n"
@@ -326,12 +315,12 @@ TEST_F(CxxParserTestSuite, cxxParserFindsMultipleAnonymousStructDeclarationsAsDi
       "	float x;\n"
       "};\n");
 
-  EXPECT_TRUE(client->structs.size() == 2);
-  EXPECT_TRUE(client->fields.size() == 2);
+  EXPECT_EQ(client->structs.size(), 2);
+  EXPECT_EQ(client->fields.size(), 2);
   EXPECT_TRUE(utility::substrBeforeLast(client->fields[0], '<') != utility::substrBeforeLast(client->fields[1], '<'));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsAnonymousUnionDeclaration) {
+TEST_F(CxxParserTestSuite, FindsAnonymousUnionDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode(
       "typedef union\n"
       "{\n"
@@ -339,43 +328,43 @@ TEST_F(CxxParserTestSuite, cxxParserFindsAnonymousUnionDeclaration) {
       "	float f;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->unions, L"anonymous union (temp.cpp<1:9>) <1:9 <1:9 1:13> 5:1>"));
+  EXPECT_THAT(client->unions, testing::Contains(L"anonymous union (temp.cpp<1:9>) <1:9 <1:9 1:13> 5:1>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNameOfAnonymousStructDeclaredInsideTypedef) {
+TEST_F(CxxParserTestSuite, FindsNameOfAnonymousStructDeclaredInsideTypedef) {
   std::shared_ptr<TestStorage> client = parseCode(
       "typedef struct\n"
       "{\n"
       "	int x;\n"
       "} Foo;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->structs, L"Foo <1:9 <1:9 1:14> 4:1>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->structs, L"Foo <4:3 4:5>"));
+  EXPECT_THAT(client->structs, testing::Contains(L"Foo <1:9 <1:9 1:14> 4:1>"));
+  EXPECT_THAT(client->structs, testing::Contains(L"Foo <4:3 4:5>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNameOfAnonymousClassDeclaredInsideTypedef) {
+TEST_F(CxxParserTestSuite, FindsNameOfAnonymousClassDeclaredInsideTypedef) {
   std::shared_ptr<TestStorage> client = parseCode(
       "typedef class\n"
       "{\n"
       "	int x;\n"
       "} Foo;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->classes, L"Foo <1:9 <1:9 1:13> 4:1>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->classes, L"Foo <4:3 4:5>"));
+  EXPECT_THAT(client->classes, testing::Contains(L"Foo <1:9 <1:9 1:13> 4:1>"));
+  EXPECT_THAT(client->classes, testing::Contains(L"Foo <4:3 4:5>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNameOfAnonymousEnumDeclaredInsideTypedef) {
+TEST_F(CxxParserTestSuite, FindsNameOfAnonymousEnumDeclaredInsideTypedef) {
   std::shared_ptr<TestStorage> client = parseCode(
       "typedef enum\n"
       "{\n"
       "	CONSTANT_1;\n"
       "} Foo;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->enums, L"Foo <1:9 <1:9 1:12> 4:1>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->enums, L"Foo <4:3 4:5>"));
+  EXPECT_THAT(client->enums, testing::Contains(L"Foo <1:9 <1:9 1:12> 4:1>"));
+  EXPECT_THAT(client->enums, testing::Contains(L"Foo <4:3 4:5>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNameOfAnonymousUnionDeclaredInsideTypedef) {
+TEST_F(CxxParserTestSuite, FindsNameOfAnonymousUnionDeclaredInsideTypedef) {
   std::shared_ptr<TestStorage> client = parseCode(
       "typedef union\n"
       "{\n"
@@ -383,44 +372,44 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNameOfAnonymousUnionDeclaredInsideTyped
       "	float y;\n"
       "} Foo;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->unions, L"Foo <1:9 <1:9 1:13> 5:1>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->unions, L"Foo <5:3 5:5>"));
+  EXPECT_THAT(client->unions, testing::Contains(L"Foo <1:9 <1:9 1:13> 5:1>"));
+  EXPECT_THAT(client->unions, testing::Contains(L"Foo <5:3 5:5>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNameOfAnonymousStructDeclaredInsideTypeAlias) {
+TEST_F(CxxParserTestSuite, FindsNameOfAnonymousStructDeclaredInsideTypeAlias) {
   std::shared_ptr<TestStorage> client = parseCode(
       "using Foo = struct\n"
       "{\n"
       "	int x;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->structs, L"Foo <1:13 <1:13 1:18> 4:1>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->structs, L"Foo <1:7 1:9>"));
+  EXPECT_THAT(client->structs, testing::Contains(L"Foo <1:13 <1:13 1:18> 4:1>"));
+  EXPECT_THAT(client->structs, testing::Contains(L"Foo <1:7 1:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNameOfAnonymousClassDeclaredInsideTypeAlias) {
+TEST_F(CxxParserTestSuite, FindsNameOfAnonymousClassDeclaredInsideTypeAlias) {
   std::shared_ptr<TestStorage> client = parseCode(
       "using Foo = class\n"
       "{\n"
       "	int x;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->classes, L"Foo <1:13 <1:13 1:17> 4:1>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->classes, L"Foo <1:7 1:9>"));
+  EXPECT_THAT(client->classes, testing::Contains(L"Foo <1:13 <1:13 1:17> 4:1>"));
+  EXPECT_THAT(client->classes, testing::Contains(L"Foo <1:7 1:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNameOfAnonymousEnumDeclaredInsideTypeAlias) {
+TEST_F(CxxParserTestSuite, FindsNameOfAnonymousEnumDeclaredInsideTypeAlias) {
   std::shared_ptr<TestStorage> client = parseCode(
       "using Foo = enum\n"
       "{\n"
       "	CONSTANT_1;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->enums, L"Foo <1:13 <1:13 1:16> 4:1>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->enums, L"Foo <1:7 1:9>"));
+  EXPECT_THAT(client->enums, testing::Contains(L"Foo <1:13 <1:13 1:16> 4:1>"));
+  EXPECT_THAT(client->enums, testing::Contains(L"Foo <1:7 1:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNameOfAnonymousUnionDeclaredInsideTypeAlias) {
+TEST_F(CxxParserTestSuite, FindsNameOfAnonymousUnionDeclaredInsideTypeAlias) {
   std::shared_ptr<TestStorage> client = parseCode(
       "using Foo = union\n"
       "{\n"
@@ -428,86 +417,86 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNameOfAnonymousUnionDeclaredInsideTypeA
       "	float y;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->unions, L"Foo <1:13 <1:13 1:17> 5:1>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->unions, L"Foo <1:7 1:9>"));
+  EXPECT_THAT(client->unions, testing::Contains(L"Foo <1:13 <1:13 1:17> 5:1>"));
+  EXPECT_THAT(client->unions, testing::Contains(L"Foo <1:7 1:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsEnumDefinedInGlobalNamespace) {
+TEST_F(CxxParserTestSuite, FindsEnumDefinedInGlobalNamespace) {
   std::shared_ptr<TestStorage> client = parseCode(
       "enum E\n"
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->enums, L"E <1:1 <1:6 1:6> 3:1>"));
+  EXPECT_THAT(client->enums, testing::Contains(L"E <1:1 <1:6 1:6> 3:1>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsEnumConstantInGlobalEnum) {
+TEST_F(CxxParserTestSuite, FindsEnumConstantInGlobalEnum) {
   std::shared_ptr<TestStorage> client = parseCode(
       "enum E\n"
       "{\n"
       "	P\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->enumConstants, L"E::P <3:2 3:2>"));
+  EXPECT_THAT(client->enumConstants, testing::Contains(L"E::P <3:2 3:2>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypedefInGlobalNamespace) {
+TEST_F(CxxParserTestSuite, FindsTypedefInGlobalNamespace) {
   std::shared_ptr<TestStorage> client = parseCode("typedef unsigned int uint;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typedefs, L"uint <1:22 1:25>"));
+  EXPECT_THAT(client->typedefs, testing::Contains(L"uint <1:22 1:25>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypedefInNamedNamespace) {
+TEST_F(CxxParserTestSuite, FindsTypedefInNamedNamespace) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace test\n"
       "{\n"
       "	typedef unsigned int uint;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typedefs, L"test::uint <3:23 3:26>"));
+  EXPECT_THAT(client->typedefs, testing::Contains(L"test::uint <3:23 3:26>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypedefInAnonymousNamespace) {
+TEST_F(CxxParserTestSuite, FindsTypedefInAnonymousNamespace) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace\n"
       "{\n"
       "	typedef unsigned int uint;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typedefs, L"anonymous namespace (temp.cpp<1:1>)::uint <3:23 3:26>"));
+  EXPECT_THAT(client->typedefs, testing::Contains(L"anonymous namespace (temp.cpp<1:1>)::uint <3:23 3:26>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeAliasInClass) {
+TEST_F(CxxParserTestSuite, FindsTypeAliasInClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class Foo\n"
       "{\n"
       "	using Bar = Foo;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typedefs, L"private Foo::Bar <3:8 3:10>"));
+  EXPECT_THAT(client->typedefs, testing::Contains(L"private Foo::Bar <3:8 3:10>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMacroDefine) {
+TEST_F(CxxParserTestSuite, FindsMacroDefine) {
   std::shared_ptr<TestStorage> client = parseCode(
       "#define PI\n"
       "void test()\n"
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->macros, L"PI <1:9 1:10>"));
+  EXPECT_THAT(client->macros, testing::Contains(L"PI <1:9 1:10>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMacroUndefine) {
+TEST_F(CxxParserTestSuite, FindsMacroUndefine) {
   std::shared_ptr<TestStorage> client = parseCode(
       "#undef PI\n"
       "void test()\n"
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->macroUses, L"temp.cpp -> PI <1:8 1:9>"));
+  EXPECT_THAT(client->macroUses, testing::Contains(L"temp.cpp -> PI <1:8 1:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMacroInIfdef) {
+TEST_F(CxxParserTestSuite, FindsMacroInIfdef) {
   std::shared_ptr<TestStorage> client = parseCode(
       "#define PI\n"
       "#ifdef PI\n"
@@ -516,10 +505,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsMacroInIfdef) {
       "};\n"
       "#endif\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->macroUses, L"temp.cpp -> PI <2:8 2:9>"));
+  EXPECT_THAT(client->macroUses, testing::Contains(L"temp.cpp -> PI <2:8 2:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMacroInIfndef) {
+TEST_F(CxxParserTestSuite, FindsMacroInIfndef) {
   std::shared_ptr<TestStorage> client = parseCode(
       "#define PI\n"
       "#ifndef PI\n"
@@ -528,10 +517,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsMacroInIfndef) {
       "};\n"
       "#endif\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->macroUses, L"temp.cpp -> PI <2:9 2:10>"));
+  EXPECT_THAT(client->macroUses, testing::Contains(L"temp.cpp -> PI <2:9 2:10>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMacroInIfdefined) {
+TEST_F(CxxParserTestSuite, FindsMacroInIfdefined) {
   std::shared_ptr<TestStorage> client = parseCode(
       "#define PI\n"
       "#if defined(PI)\n"
@@ -540,10 +529,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsMacroInIfdefined) {
       "};\n"
       "#endif\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->macroUses, L"temp.cpp -> PI <2:13 2:14>"));
+  EXPECT_THAT(client->macroUses, testing::Contains(L"temp.cpp -> PI <2:13 2:14>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMacroExpand) {
+TEST_F(CxxParserTestSuite, FindsMacroExpand) {
   std::shared_ptr<TestStorage> client = parseCode(
       "#define PI 3.14159265359\n"
       "void test()\n"
@@ -551,10 +540,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsMacroExpand) {
       "double i = PI;"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->macroUses, L"temp.cpp -> PI <4:12 4:13>"));
+  EXPECT_THAT(client->macroUses, testing::Contains(L"temp.cpp -> PI <4:12 4:13>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMacroExpandWithinMacro) {
+TEST_F(CxxParserTestSuite, FindsMacroExpandWithinMacro) {
   std::shared_ptr<TestStorage> client = parseCode(
       "#define PI 3.14159265359\n"
       "#define TAU (2 * PI)\n"
@@ -563,36 +552,36 @@ TEST_F(CxxParserTestSuite, cxxParserFindsMacroExpandWithinMacro) {
       "double i = TAU;"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->macroUses, L"temp.cpp -> PI <2:18 2:19>"));
+  EXPECT_THAT(client->macroUses, testing::Contains(L"temp.cpp -> PI <2:18 2:19>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMacroDefineScope) {
+TEST_F(CxxParserTestSuite, FindsMacroDefineScope) {
   std::shared_ptr<TestStorage> client = parseCode(
       "#define MAX(a,b) \\\n"
       "	((a)>(b)?(a):(b))");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->macros, L"MAX <1:9 <1:9 1:11> 2:17>"));
+  EXPECT_THAT(client->macros, testing::Contains(L"MAX <1:9 <1:9 1:11> 2:17>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateParameterDefinitionOfTemplateTypeAlias) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateParameterDefinitionOfTemplateTypeAlias) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template<class T>\n"
       "using MyType = int;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:16> <1:16 1:16>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:16> <1:16 1:16>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateParameterDefinitionOfClassTemplate) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateParameterDefinitionOfClassTemplate) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:20> <1:20 1:20>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:20> <1:20 1:20>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateParameterDefinitionOfExplicitPartialClassTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateParameterDefinitionOfExplicitPartialClassTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T, typename U>\n"
       "class A\n"
@@ -603,20 +592,20 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateParameterDefinitionOfExplic
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<5:20> <5:20 5:20>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<5:20> <5:20 5:20>"));
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<5:20> <6:9 6:9>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<5:20> <6:9 6:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateParameterDefinitionOfVariableTemplate) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateParameterDefinitionOfVariableTemplate) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "T v;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:20> <1:20 1:20>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:20> <1:20 1:20>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateParameterDefinitionOfExplicitPartialVariableTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateParameterDefinitionOfExplicitPartialVariableTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T, typename Q>\n"
       "T t = Q(5);\n"
@@ -624,42 +613,42 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateParameterDefinitionOfExplic
       "template <typename R>\n"
       "int t<int, R> = 9;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<4:20> <4:20 4:20>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<4:20> <4:20 4:20>"));
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<4:20> <5:12 5:12>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<4:20> <5:12 5:12>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateParameterDefinedWithClassKeyword) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateParameterDefinedWithClassKeyword) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <class T>\n"
       "class A\n"
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:17> <1:17 1:17>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:17> <1:17 1:17>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeIntTemplateParameterDefinitionOfTemplateClass) {
+TEST_F(CxxParserTestSuite, FindsNonTypeIntTemplateParameterDefinitionOfTemplateClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <int T>\n"
       "class A\n"
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:15> <1:15 1:15>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:15> <1:15 1:15>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeBoolTemplateParameterDefinitionOfTemplateClass) {
+TEST_F(CxxParserTestSuite, FindsNonTypeBoolTemplateParameterDefinitionOfTemplateClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <bool T>\n"
       "class A\n"
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:16> <1:16 1:16>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:16> <1:16 1:16>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeCustomPointerTemplateParameterDefinitionOfTemplateClass) {
+TEST_F(CxxParserTestSuite, FindsNonTypeCustomPointerTemplateParameterDefinitionOfTemplateClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class P\n"
       "{};\n"
@@ -667,10 +656,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeCustomPointerTemplateParameterDe
       "class A\n"
       "{};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<3:14> <3:14 3:14>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<3:14> <3:14 3:14>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeCustomReferenceTemplateParameterDefinitionOfTemplateClass) {
+TEST_F(CxxParserTestSuite, FindsNonTypeCustomReferenceTemplateParameterDefinitionOfTemplateClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class P\n"
       "{};\n"
@@ -678,30 +667,30 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeCustomReferenceTemplateParameter
       "class A\n"
       "{};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<3:14> <3:14 3:14>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<3:14> <3:14 3:14>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeTemplateParameterDefinitionThatDependsOnTypeTemplateParameterOfTemplateClass) {
+TEST_F(CxxParserTestSuite, FindsNonTypeTemplateParameterDefinitionThatDependsOnTypeTemplateParameterOfTemplateClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T1, T1& T2>\n"
       "class A\n"
       "{};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:28> <1:28 1:29>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:28> <1:28 1:29>"));
 
   // and usage
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:20> <1:24 1:25>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:20> <1:24 1:25>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeTemplateParameterDefinitionThatDependsOnTemplateTemplateParameterOfTemplateClass) {
+TEST_F(CxxParserTestSuite, FindsNonTypeTemplateParameterDefinitionThatDependsOnTemplateTemplateParameterOfTemplateClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <template<typename> class T1, T1<int>& T2>\n"
       "class A\n"
       "{};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:49> <1:49 1:50>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:49> <1:49 1:50>"));
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:36> <1:40 1:41>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:36> <1:40 1:41>"));
 }
 
 TEST_F(CxxParserTestSuite,
@@ -712,19 +701,18 @@ TEST_F(CxxParserTestSuite,
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:45> <1:45 1:45>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:45> <1:45 1:45>"));
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:29> <1:32 1:32>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:29> <1:32 1:32>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateArgumentOfDependentNonTypeTemplateParameter) {
+TEST_F(CxxParserTestSuite, FindsTemplateArgumentOfDependentNonTypeTemplateParameter) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <template<typename> class T1, T1<int>& T2>\n"
       "class A\n"
       "{};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->typeUses, L"A<template<typename> typename T1, T1<int> & T2> -> int <1:43 1:45>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<template<typename> typename T1, T1<int> & T2> -> int <1:43 1:45>"));
 }
 
 // void _test_foofoo()
@@ -748,7 +736,7 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateArgumentOfDependentNonTypeTempl
 //	));
 //}
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateTemplateParameterOfTemplateClass) {
+TEST_F(CxxParserTestSuite, FindsTemplateTemplateParameterOfTemplateClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -761,51 +749,51 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateTemplateParameterOfTemplateClas
       "	B<A> ba;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<4:36> <4:36 4:36>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<4:36> <4:36 4:36>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateParameterPackTypeOfTemplateClass) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateParameterPackTypeOfTemplateClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename... T>\n"
       "class A\n"
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:23> <1:23 1:23>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:23> <1:23 1:23>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeIntTemplateParameterPackTypeOfTemplateClass) {
+TEST_F(CxxParserTestSuite, FindsNonTypeIntTemplateParameterPackTypeOfTemplateClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <int... T>\n"
       "class A\n"
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:18> <1:18 1:18>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:18> <1:18 1:18>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateTemplateParameterPackTypeOfTemplateClass) {
+TEST_F(CxxParserTestSuite, FindsTemplateTemplateParameterPackTypeOfTemplateClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <template<typename> typename... T>\n"
       "class A\n"
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:42> <1:42 1:42>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:42> <1:42 1:42>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateParametersOfTemplateClassWithMultipleParameters) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateParametersOfTemplateClassWithMultipleParameters) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T, typename U>\n"
       "class A\n"
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:20> <1:20 1:20>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:32> <1:32 1:32>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:20> <1:20 1:20>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:32> <1:32 1:32>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserSkipsCreatingNodeForTemplateParameterWithoutAName) {
+TEST_F(CxxParserTestSuite, SkipsCreatingNodeForTemplateParameterWithoutAName) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename>\n"
       "class A\n"
@@ -813,11 +801,11 @@ TEST_F(CxxParserTestSuite, cxxParserSkipsCreatingNodeForTemplateParameterWithout
       "};\n"    // local symbol for brace
   );
 
-  EXPECT_TRUE(client->localSymbols.size() == 2);
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->classes, L"A<typename> <1:1 <2:7 2:7> 4:1>"));
+  EXPECT_EQ(client->localSymbols.size(), 2);
+  EXPECT_THAT(client->classes, testing::Contains(L"A<typename> <1:1 <2:7 2:7> 4:1>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateParameterOfTemplateMethodDefinitionOutsideTemplateClass) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateParameterOfTemplateMethodDefinitionOutsideTemplateClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -830,10 +818,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateParameterOfTemplateMethodDe
       "U A<T>::foo()\n"
       "{}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<8:20> <8:20 8:20>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<8:20> <8:20 8:20>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsExplicitClassTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsExplicitClassTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -844,10 +832,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsExplicitClassTemplateSpecialization) {
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->classes, L"A<int> <5:1 <6:7 6:7> 8:1>"));
+  EXPECT_THAT(client->classes, testing::Contains(L"A<int> <5:1 <6:7 6:7> 8:1>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsExplicitVariableTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsExplicitVariableTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "T t = T(5);\n"
@@ -855,10 +843,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsExplicitVariableTemplateSpecialization)
       "template <>\n"
       "int t<int> = 99;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->globalVariables, L"int t<int> <5:5 5:5>"));
+  EXPECT_THAT(client->globalVariables, testing::Contains(L"int t<int> <5:5 5:5>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsExplicitPartialClassTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsExplicitPartialClassTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T, typename U>\n"
       "class A\n"
@@ -869,10 +857,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsExplicitPartialClassTemplateSpecializat
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->classes, L"A<typename T, int> <5:1 <6:7 6:7> 8:1>"));
+  EXPECT_THAT(client->classes, testing::Contains(L"A<typename T, int> <5:1 <6:7 6:7> 8:1>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsExplicitPartialVariableTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsExplicitPartialVariableTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T, typename Q>\n"
       "T t = Q(5);\n"
@@ -880,10 +868,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsExplicitPartialVariableTemplateSpeciali
       "template <typename R>\n"
       "int t<int, R> = 9;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->globalVariables, L"int t<int, typename R> <5:5 5:5>"));
+  EXPECT_THAT(client->globalVariables, testing::Contains(L"int t<int, typename R> <5:5 5:5>"));
 }
 
-TEST_F(CxxParserTestSuite, CxxParserFindsCorrectFieldMemberNameOfTemplateClassInDeclaration) {
+TEST_F(CxxParserTestSuite, FindsCorrectFieldMemberNameOfTemplateClassInDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -891,10 +879,10 @@ TEST_F(CxxParserTestSuite, CxxParserFindsCorrectFieldMemberNameOfTemplateClassIn
       "	int foo;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->fields, L"private int A<typename T>::foo <4:6 4:8>"));
+  EXPECT_THAT(client->fields, testing::Contains(L"private int A<typename T>::foo <4:6 4:8>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsCorrectTypeOfFieldMemberOfTemplateClassInDeclaration) {
+TEST_F(CxxParserTestSuite, FindsCorrectTypeOfFieldMemberOfTemplateClassInDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -903,16 +891,16 @@ TEST_F(CxxParserTestSuite, cxxParserFindsCorrectTypeOfFieldMemberOfTemplateClass
       "};\n"
       "A<int> a; \n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int A<int>::foo -> int <4:2 4:2>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int A<int>::foo -> int <4:2 4:2>"));
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<int> a -> A<int> <6:1 6:1>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<int> a -> A<int> <6:1 6:1>"));
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<int> a -> int <6:3 6:5>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<int> a -> int <6:3 6:5>"));
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:20> <4:2 4:2>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:20> <4:2 4:2>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsCorrectMethodMemberNameOfTemplateClassInDeclaration) {
+TEST_F(CxxParserTestSuite, FindsCorrectMethodMemberNameOfTemplateClassInDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -920,10 +908,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsCorrectMethodMemberNameOfTemplateClassI
       "	int foo();\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->methods, L"private int A<typename T>::foo() <4:2 <4:6 4:8> 4:10>"));
+  EXPECT_THAT(client->methods, testing::Contains(L"private int A<typename T>::foo() <4:2 <4:6 4:8> 4:10>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateParameterDefinitionOfTemplateFunction) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateParameterDefinitionOfTemplateFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "T test(T a)\n"
@@ -931,10 +919,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateParameterDefinitionOfTempla
       "	return a;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:20> <1:20 1:20>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:20> <1:20 1:20>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeIntTemplateParameterDefinitionOfTemplateFunction) {
+TEST_F(CxxParserTestSuite, FindsNonTypeIntTemplateParameterDefinitionOfTemplateFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <int T>\n"
       "int test(int a)\n"
@@ -942,10 +930,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeIntTemplateParameterDefinitionOf
       "	return a + T;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:15> <1:15 1:15>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:15> <1:15 1:15>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeBoolTemplateParameterDefinitionOfTemplateFunction) {
+TEST_F(CxxParserTestSuite, FindsNonTypeBoolTemplateParameterDefinitionOfTemplateFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <bool T>\n"
       "int test(int a)\n"
@@ -953,10 +941,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeBoolTemplateParameterDefinitionO
       "	return T ? a : 0;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:16> <1:16 1:16>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:16> <1:16 1:16>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeCustomPointerTemplateParameterDefinitionOfTemplateFunction) {
+TEST_F(CxxParserTestSuite, FindsNonTypeCustomPointerTemplateParameterDefinitionOfTemplateFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class P\n"
       "{};\n"
@@ -966,10 +954,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeCustomPointerTemplateParameterDe
       "	return a;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<3:14> <3:14 3:14>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<3:14> <3:14 3:14>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeCustomReferenceTemplateParameterDefinitionOfTemplateFunction) {
+TEST_F(CxxParserTestSuite, FindsNonTypeCustomReferenceTemplateParameterDefinitionOfTemplateFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class P\n"
       "{};\n"
@@ -979,10 +967,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeCustomReferenceTemplateParameter
       "	return a;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<3:14> <3:14 3:14>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<3:14> <3:14 3:14>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateTemplateParameterDefinitionOfTemplateFunction) {
+TEST_F(CxxParserTestSuite, FindsTemplateTemplateParameterDefinitionOfTemplateFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -993,10 +981,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateTemplateParameterDefinitionOfTe
       "	return a;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<4:36> <4:36 4:36>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<4:36> <4:36 4:36>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsFunctionForImplicitInstantiationOfTemplateFunction) {
+TEST_F(CxxParserTestSuite, FindsFunctionForImplicitInstantiationOfTemplateFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "T test(T a)\n"
@@ -1009,10 +997,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsFunctionForImplicitInstantiationOfTempl
       "	return test(1);\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->functions, L"int test<int>(int) <2:1 <2:1 <2:3 2:6> 2:11> 5:1>"));
+  EXPECT_THAT(client->functions, testing::Contains(L"int test<int>(int) <2:1 <2:1 <2:3 2:6> 2:11> 5:1>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserSkipsImplicitTemplateMethodDefinitionOfImplicitTemplateClassInstantiation) {
+TEST_F(CxxParserTestSuite, SkipsImplicitTemplateMethodDefinitionOfImplicitTemplateClassInstantiation) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -1028,13 +1016,12 @@ TEST_F(CxxParserTestSuite, cxxParserSkipsImplicitTemplateMethodDefinitionOfImpli
       "	return 0;\n"
       "}\n");
 
-  EXPECT_TRUE(/*NOT!*/ !utility::containsElement<std::wstring>(
-      client->methods, L"public void A<int>::foo<typename U>() <6:2 <6:7 6:9> 6:14>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->templateSpecializations, L"void A<int>::foo<float>() -> void A<typename T>::foo<typename U>() <6:7 6:9>"));
+  EXPECT_THAT(client->methods, testing::Not(testing::Contains(L"public void A<int>::foo<typename U>() <6:2 <6:7 6:9> 6:14>")));
+  EXPECT_THAT(client->templateSpecializations,
+              testing::Contains(L"void A<int>::foo<float>() -> void A<typename T>::foo<typename U>() <6:7 6:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsLambdaDefinitionAndCallInFunction) {
+TEST_F(CxxParserTestSuite, FindsLambdaDefinitionAndCallInFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "void lambdaCaller()\n"
       "{\n"
@@ -1043,13 +1030,12 @@ TEST_F(CxxParserTestSuite, cxxParserFindsLambdaDefinitionAndCallInFunction) {
 
   // TODO: fix
   // TS_ASSERT(utility::containsElement<std::wstring>(
-  // 	client->functions, L"void lambdaCaller::lambda at 3:2() const <3:5 <3:2 3:2> 3:7>"
+  // 	client->functions, testing::Contains(L"void lambdaCaller::lambda at 3:2() const <3:5 <3:2 3:2> 3:7>"
   // ));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->calls, L"void lambdaCaller() -> void lambdaCaller::lambda at 3:2() const <3:8 3:8>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"void lambdaCaller() -> void lambdaCaller::lambda at 3:2() const <3:8 3:8>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMutableLambdaDefinition) {
+TEST_F(CxxParserTestSuite, FindsMutableLambdaDefinition) {
   std::shared_ptr<TestStorage> client = parseCode(
       "void lambdaWrapper()\n"
       "{\n"
@@ -1058,44 +1044,44 @@ TEST_F(CxxParserTestSuite, cxxParserFindsMutableLambdaDefinition) {
 
   // TODO: fix
   // TS_ASSERT(utility::containsElement<std::wstring>(
-  // 	client->functions, L"int lambdaWrapper::lambda at 3:2(int) <3:14 <3:2 3:2> 3:36>"
+  // 	client->functions, testing::Contains(L"int lambdaWrapper::lambda at 3:2(int) <3:14 <3:2 3:2> 3:36>"
   // ));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsLocalVariableDeclaredInLambdaCapture) {
+TEST_F(CxxParserTestSuite, FindsLocalVariableDeclaredInLambdaCapture) {
   std::shared_ptr<TestStorage> client = parseCode(
       "void lambdaWrapper()\n"
       "{\n"
       "	[x(42)]() { return x; };\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<3:3> <3:3 3:3>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<3:3> <3:21 3:21>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<3:3> <3:3 3:3>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<3:3> <3:21 3:21>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsDefinitionOfLocalSymbolInFunctionParameterList) {
+TEST_F(CxxParserTestSuite, FindsDefinitionOfLocalSymbolInFunctionParameterList) {
   std::shared_ptr<TestStorage> client = parseCode(
       "void test(int a)\n"
       "{\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:15> <1:15 1:15>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:15> <1:15 1:15>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsDefinitionOfLocalSymbolInFunctionScope) {
+TEST_F(CxxParserTestSuite, FindsDefinitionOfLocalSymbolInFunctionScope) {
   std::shared_ptr<TestStorage> client = parseCode(
       "void test()\n"
       "{\n"
       "	int a;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<3:6> <3:6 3:6>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<3:6> <3:6 3:6>"));
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // test finding nested symbol definitions and declarations
 
-TEST_F(CxxParserTestSuite, cxxParserFindsClassDefinitionInClass) {
+TEST_F(CxxParserTestSuite, FindsClassDefinitionInClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A\n"
       "{\n"
@@ -1103,20 +1089,20 @@ TEST_F(CxxParserTestSuite, cxxParserFindsClassDefinitionInClass) {
       "	class B;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->classes, L"public A::B <4:8 4:8>"));
+  EXPECT_THAT(client->classes, testing::Contains(L"public A::B <4:8 4:8>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsClassDefinitionInNamespace) {
+TEST_F(CxxParserTestSuite, FindsClassDefinitionInNamespace) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace a\n"
       "{\n"
       "	class B;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->classes, L"a::B <3:8 3:8>"));
+  EXPECT_THAT(client->classes, testing::Contains(L"a::B <3:8 3:8>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsStructDefinitionInClass) {
+TEST_F(CxxParserTestSuite, FindsStructDefinitionInClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A\n"
       "{\n"
@@ -1125,10 +1111,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsStructDefinitionInClass) {
       "	};\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->structs, L"private A::B <3:2 <3:9 3:9> 5:2>"));
+  EXPECT_THAT(client->structs, testing::Contains(L"private A::B <3:2 <3:9 3:9> 5:2>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsStructDefinitionInNamespace) {
+TEST_F(CxxParserTestSuite, FindsStructDefinitionInNamespace) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace A\n"
       "{\n"
@@ -1137,10 +1123,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsStructDefinitionInNamespace) {
       "	};\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->structs, L"A::B <3:2 <3:9 3:9> 5:2>"));
+  EXPECT_THAT(client->structs, testing::Contains(L"A::B <3:2 <3:9 3:9> 5:2>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsStructDefinitionInFunction) {
+TEST_F(CxxParserTestSuite, FindsStructDefinitionInFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "void foo(int)\n"
       "{\n"
@@ -1155,21 +1141,21 @@ TEST_F(CxxParserTestSuite, cxxParserFindsStructDefinitionInFunction) {
       "	};\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->structs, L"foo::B <3:2 <3:9 3:9> 5:2>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->structs, L"foo::B <9:2 <9:9 9:9> 11:2>"));
+  EXPECT_THAT(client->structs, testing::Contains(L"foo::B <3:2 <3:9 3:9> 5:2>"));
+  EXPECT_THAT(client->structs, testing::Contains(L"foo::B <9:2 <9:9 9:9> 11:2>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsVariableDefinitionsInNamespaceScope) {
+TEST_F(CxxParserTestSuite, FindsVariableDefinitionsInNamespaceScope) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace n"
       "{\n"
       "	int x;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->globalVariables, L"int n::x <2:6 2:6>"));
+  EXPECT_THAT(client->globalVariables, testing::Contains(L"int n::x <2:6 2:6>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsFieldInNestedClass) {
+TEST_F(CxxParserTestSuite, FindsFieldInNestedClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class B\n"
       "{\n"
@@ -1181,21 +1167,20 @@ TEST_F(CxxParserTestSuite, cxxParserFindsFieldInNestedClass) {
       "	};\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->fields, L"private static const int B::C::amount <7:20 7:25>"));
+  EXPECT_THAT(client->fields, testing::Contains(L"private static const int B::C::amount <7:20 7:25>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsFunctionInAnonymousNamespace) {
+TEST_F(CxxParserTestSuite, FindsFunctionInAnonymousNamespace) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace\n"
       "{\n"
       "	int sum(int a, int b);\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->functions, L"int anonymous namespace (temp.cpp<1:1>)::sum(int, int) <3:2 <3:6 3:8> 3:22>"));
+  EXPECT_THAT(client->functions, testing::Contains(L"int anonymous namespace (temp.cpp<1:1>)::sum(int, int) <3:2 <3:6 3:8> 3:22>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMethodDeclaredInNestedClass) {
+TEST_F(CxxParserTestSuite, FindsMethodDeclaredInNestedClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class B\n"
       "{\n"
@@ -1205,11 +1190,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsMethodDeclaredInNestedClass) {
       "	};\n"
       "};\n");
 
-  EXPECT_TRUE(
-      utility::containsElement<std::wstring>(client->methods, L"private bool B::C::isGreat() const <5:3 <5:8 5:14> 5:22>"));
+  EXPECT_THAT(client->methods, testing::Contains(L"private bool B::C::isGreat() const <5:3 <5:8 5:14> 5:22>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNestedNamedNamespace) {
+TEST_F(CxxParserTestSuite, FindsNestedNamedNamespace) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace A\n"
       "{\n"
@@ -1218,10 +1202,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNestedNamedNamespace) {
       "	}\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->namespaces, L"A::B <3:2 <3:12 3:12> 5:2>"));
+  EXPECT_THAT(client->namespaces, testing::Contains(L"A::B <3:2 <3:12 3:12> 5:2>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsEnumDefinedInClass) {
+TEST_F(CxxParserTestSuite, FindsEnumDefinedInClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class B\n"
       "{\n"
@@ -1231,10 +1215,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsEnumDefinedInClass) {
       "	};\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->enums, L"public B::Z <4:2 <4:7 4:7> 6:2>"));
+  EXPECT_THAT(client->enums, testing::Contains(L"public B::Z <4:2 <4:7 4:7> 6:2>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsEnumDefinedInNamespace) {
+TEST_F(CxxParserTestSuite, FindsEnumDefinedInNamespace) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace n\n"
       "{\n"
@@ -1243,10 +1227,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsEnumDefinedInNamespace) {
       "	};\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->enums, L"n::Z <3:2 <3:7 3:7> 5:2>"));
+  EXPECT_THAT(client->enums, testing::Contains(L"n::Z <3:2 <3:7 3:7> 5:2>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsEnumDefinitionInTemplateClass) {
+TEST_F(CxxParserTestSuite, FindsEnumDefinitionInTemplateClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -1258,10 +1242,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsEnumDefinitionInTemplateClass) {
       "	};\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->enums, L"private A<typename T>::TestType <4:2 <4:7 4:14> 8:2>"));
+  EXPECT_THAT(client->enums, testing::Contains(L"private A<typename T>::TestType <4:2 <4:7 4:14> 8:2>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsEnumConstantsInTemplateClass) {
+TEST_F(CxxParserTestSuite, FindsEnumConstantsInTemplateClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -1273,13 +1257,13 @@ TEST_F(CxxParserTestSuite, cxxParserFindsEnumConstantsInTemplateClass) {
       "	};\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->enumConstants, L"A<typename T>::TestType::TEST_ONE <6:3 6:10>"));
+  EXPECT_THAT(client->enumConstants, testing::Contains(L"A<typename T>::TestType::TEST_ONE <6:3 6:10>"));
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // test qualifier locations
 
-TEST_F(CxxParserTestSuite, cxxParserFindsQualifierOfAccessToGlobalVariableDefinedInNamespace) {
+TEST_F(CxxParserTestSuite, FindsQualifierOfAccessToGlobalVariableDefinedInNamespace) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace foo {\n"
       "	namespace bar {\n"
@@ -1290,11 +1274,11 @@ TEST_F(CxxParserTestSuite, cxxParserFindsQualifierOfAccessToGlobalVariableDefine
       "	foo::bar::x = 9;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->qualifiers, L"foo <7:2 7:4>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->qualifiers, L"foo::bar <7:7 7:9>"));
+  EXPECT_THAT(client->qualifiers, testing::Contains(L"foo <7:2 7:4>"));
+  EXPECT_THAT(client->qualifiers, testing::Contains(L"foo::bar <7:7 7:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsQualifierOfAccessToStaticField) {
+TEST_F(CxxParserTestSuite, FindsQualifierOfAccessToStaticField) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class Foo {\n"
       "public:\n"
@@ -1307,11 +1291,11 @@ TEST_F(CxxParserTestSuite, cxxParserFindsQualifierOfAccessToStaticField) {
       "	Foo::Bar::x = 9;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->qualifiers, L"Foo <9:2 9:4>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->qualifiers, L"Foo::Bar <9:7 9:9>"));
+  EXPECT_THAT(client->qualifiers, testing::Contains(L"Foo <9:2 9:4>"));
+  EXPECT_THAT(client->qualifiers, testing::Contains(L"Foo::Bar <9:7 9:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsQualifierOfAccessToEnumConstant) {
+TEST_F(CxxParserTestSuite, FindsQualifierOfAccessToEnumConstant) {
   std::shared_ptr<TestStorage> client = parseCode(
       "enum Foo {\n"
       "	FOO_V\n"
@@ -1320,10 +1304,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsQualifierOfAccessToEnumConstant) {
       "	Foo v = Foo::FOO_V;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->qualifiers, L"Foo <5:10 5:12>"));
+  EXPECT_THAT(client->qualifiers, testing::Contains(L"Foo <5:10 5:12>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsQualifierOfReferenceToMethod) {
+TEST_F(CxxParserTestSuite, FindsQualifierOfReferenceToMethod) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class Foo {\n"
       "public:\n"
@@ -1336,10 +1320,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsQualifierOfReferenceToMethod) {
       "	foo = &Foo::my_int_func;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->qualifiers, L"Foo <9:9 9:11>"));
+  EXPECT_THAT(client->qualifiers, testing::Contains(L"Foo <9:9 9:11>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsQualifierOfConstructorCall) {
+TEST_F(CxxParserTestSuite, FindsQualifierOfConstructorCall) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class Foo {\n"
       "public:\n"
@@ -1351,27 +1335,27 @@ TEST_F(CxxParserTestSuite, cxxParserFindsQualifierOfConstructorCall) {
       "	Bar() : Foo::Foo(4) {}\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->qualifiers, L"Foo <8:10 8:12>"));
+  EXPECT_THAT(client->qualifiers, testing::Contains(L"Foo <8:10 8:12>"));
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // test implicit symbols
 
-TEST_F(CxxParserTestSuite, cxxParserFindsBuiltinTypes) {
+TEST_F(CxxParserTestSuite, FindsBuiltinTypes) {
   std::shared_ptr<TestStorage> client = parseCode(
       "void t1(int v) {}\n"
       "void t2(float v) {}\n"
       "void t3(double v) {}\n"
       "void t4(bool v) {}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->builtinTypes, L"void"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->builtinTypes, L"int"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->builtinTypes, L"float"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->builtinTypes, L"double"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->builtinTypes, L"bool"));
+  EXPECT_THAT(client->builtinTypes, testing::Contains(L"void"));
+  EXPECT_THAT(client->builtinTypes, testing::Contains(L"int"));
+  EXPECT_THAT(client->builtinTypes, testing::Contains(L"float"));
+  EXPECT_THAT(client->builtinTypes, testing::Contains(L"double"));
+  EXPECT_THAT(client->builtinTypes, testing::Contains(L"bool"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsImplicitCopyConstructor) {
+TEST_F(CxxParserTestSuite, FindsImplicitCopyConstructor) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class TestClass {}\n"
       "void foo()\n"
@@ -1380,18 +1364,15 @@ TEST_F(CxxParserTestSuite, cxxParserFindsImplicitCopyConstructor) {
       "	TestClass b(a);\n"
       "}\n");
 
-  EXPECT_TRUE(
-      utility::containsElement<std::wstring>(client->methods, L"public void TestClass::TestClass() <1:7 <1:7 1:15> 1:15>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->methods, L"public void TestClass::TestClass(const TestClass &) <1:7 <1:7 1:15> 1:15>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->methods, L"public void TestClass::TestClass(TestClass &&) <1:7 <1:7 1:15> 1:15>"));
+  EXPECT_THAT(client->methods, testing::Contains(L"public void TestClass::TestClass() <1:7 <1:7 1:15> 1:15>"));
+  EXPECT_THAT(client->methods, testing::Contains(L"public void TestClass::TestClass(const TestClass &) <1:7 <1:7 1:15> 1:15>"));
+  EXPECT_THAT(client->methods, testing::Contains(L"public void TestClass::TestClass(TestClass &&) <1:7 <1:7 1:15> 1:15>"));
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // test finding usages of symbols
 
-TEST_F(CxxParserTestSuite, cxxParserFindsEnumUsageInTemplateClass) {
+TEST_F(CxxParserTestSuite, FindsEnumUsageInTemplateClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -1404,11 +1385,11 @@ TEST_F(CxxParserTestSuite, cxxParserFindsEnumUsageInTemplateClass) {
       "	TestType foo;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->typeUses, L"A<typename T>::TestType A<typename T>::foo -> A<typename T>::TestType <9:2 9:9>"));
+  EXPECT_THAT(
+      client->typeUses, testing::Contains(L"A<typename T>::TestType A<typename T>::foo -> A<typename T>::TestType <9:2 9:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsCorrectFieldMemberTypeOfNestedTemplateClassInDeclaration) {
+TEST_F(CxxParserTestSuite, FindsCorrectFieldMemberTypeOfNestedTemplateClassInDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -1422,27 +1403,27 @@ TEST_F(CxxParserTestSuite, cxxParserFindsCorrectFieldMemberTypeOfNestedTemplateC
       "A<int> a;\n"
       "A<int>::B b;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:20> <7:3 7:3>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int A<int>::B::foo -> int <7:3 7:3>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<int> a -> A<int> <10:1 10:1>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<int> -> int <10:3 10:5>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<int> a -> int <10:3 10:5>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<int>::B b -> A<int>::B <11:9 11:9>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:20> <7:3 7:3>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int A<int>::B::foo -> int <7:3 7:3>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<int> a -> A<int> <10:1 10:1>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<int> -> int <10:3 10:5>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<int> a -> int <10:3 10:5>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<int>::B b -> A<int>::B <11:9 11:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeUsageOfGlobalVariable) {
+TEST_F(CxxParserTestSuite, FindsTypeUsageOfGlobalVariable) {
   std::shared_ptr<TestStorage> client = parseCode("int x;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int x -> int <1:1 1:3>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int x -> int <1:1 1:3>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypedefsTypeUse) {
+TEST_F(CxxParserTestSuite, FindsTypedefsTypeUse) {
   std::shared_ptr<TestStorage> client = parseCode("typedef unsigned int uint;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"uint -> unsigned int <1:9 1:16>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"uint -> unsigned int <1:9 1:16>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypedefThatUsesTypeDefinedInNamedNamespace) {
+TEST_F(CxxParserTestSuite, FindsTypedefThatUsesTypeDefinedInNamedNamespace) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace test\n"
       "{\n"
@@ -1450,50 +1431,50 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypedefThatUsesTypeDefinedInNamedNamesp
       "}\n"
       "typedef test::TestStruct globalTestStruct;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"globalTestStruct -> test::TestStruct <5:15 5:24>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"globalTestStruct -> test::TestStruct <5:15 5:24>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeUseOfTypedef) {
+TEST_F(CxxParserTestSuite, FindsTypeUseOfTypedef) {
   std::shared_ptr<TestStorage> client = parseCode(
       "typedef unsigned int uint;\n"
       "uint number;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"uint number -> uint <2:1 2:4>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"uint number -> uint <2:1 2:4>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsClassDefaultPrivateInheritance) {
+TEST_F(CxxParserTestSuite, FindsClassDefaultPrivateInheritance) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A {};\n"
       "class B : A {};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->inheritances, L"B -> A <2:11 2:11>"));
+  EXPECT_THAT(client->inheritances, testing::Contains(L"B -> A <2:11 2:11>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsClassPublicInheritance) {
+TEST_F(CxxParserTestSuite, FindsClassPublicInheritance) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A {};\n"
       "class B : public A {};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->inheritances, L"B -> A <2:18 2:18>"));
+  EXPECT_THAT(client->inheritances, testing::Contains(L"B -> A <2:18 2:18>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsClassProtectedInheritance) {
+TEST_F(CxxParserTestSuite, FindsClassProtectedInheritance) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A {};\n"
       "class B : protected A {};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->inheritances, L"B -> A <2:21 2:21>"));
+  EXPECT_THAT(client->inheritances, testing::Contains(L"B -> A <2:21 2:21>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsClassPrivateInheritance) {
+TEST_F(CxxParserTestSuite, FindsClassPrivateInheritance) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A {};\n"
       "class B : private A {};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->inheritances, L"B -> A <2:19 2:19>"));
+  EXPECT_THAT(client->inheritances, testing::Contains(L"B -> A <2:19 2:19>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsClassMultipleInheritance) {
+TEST_F(CxxParserTestSuite, FindsClassMultipleInheritance) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A {};\n"
       "class B {};\n"
@@ -1502,43 +1483,43 @@ TEST_F(CxxParserTestSuite, cxxParserFindsClassMultipleInheritance) {
       "	, private B\n"
       "{};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->inheritances, L"C -> A <4:11 4:11>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->inheritances, L"C -> B <5:12 5:12>"));
+  EXPECT_THAT(client->inheritances, testing::Contains(L"C -> A <4:11 4:11>"));
+  EXPECT_THAT(client->inheritances, testing::Contains(L"C -> B <5:12 5:12>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsStructDefaultPublicInheritance) {
+TEST_F(CxxParserTestSuite, FindsStructDefaultPublicInheritance) {
   std::shared_ptr<TestStorage> client = parseCode(
       "struct A {};\n"
       "struct B : A {};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->inheritances, L"B -> A <2:12 2:12>"));
+  EXPECT_THAT(client->inheritances, testing::Contains(L"B -> A <2:12 2:12>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsStructPublicInheritance) {
+TEST_F(CxxParserTestSuite, FindsStructPublicInheritance) {
   std::shared_ptr<TestStorage> client = parseCode(
       "struct A {};\n"
       "struct B : public A {};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->inheritances, L"B -> A <2:19 2:19>"));
+  EXPECT_THAT(client->inheritances, testing::Contains(L"B -> A <2:19 2:19>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsStructProtectedInheritance) {
+TEST_F(CxxParserTestSuite, FindsStructProtectedInheritance) {
   std::shared_ptr<TestStorage> client = parseCode(
       "struct A {};\n"
       "struct B : protected A {};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->inheritances, L"B -> A <2:22 2:22>"));
+  EXPECT_THAT(client->inheritances, testing::Contains(L"B -> A <2:22 2:22>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsStructPrivateInheritance) {
+TEST_F(CxxParserTestSuite, FindsStructPrivateInheritance) {
   std::shared_ptr<TestStorage> client = parseCode(
       "struct A {};\n"
       "struct B : private A {};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->inheritances, L"B -> A <2:20 2:20>"));
+  EXPECT_THAT(client->inheritances, testing::Contains(L"B -> A <2:20 2:20>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsStructMultipleInheritance) {
+TEST_F(CxxParserTestSuite, FindsStructMultipleInheritance) {
   std::shared_ptr<TestStorage> client = parseCode(
       "struct A {};\n"
       "struct B {};\n"
@@ -1547,11 +1528,11 @@ TEST_F(CxxParserTestSuite, cxxParserFindsStructMultipleInheritance) {
       "	, private B\n"
       "{};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->inheritances, L"C -> A <4:11 4:11>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->inheritances, L"C -> B <5:12 5:12>"));
+  EXPECT_THAT(client->inheritances, testing::Contains(L"C -> A <4:11 4:11>"));
+  EXPECT_THAT(client->inheritances, testing::Contains(L"C -> B <5:12 5:12>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMethodOverrideWhenVirtual) {
+TEST_F(CxxParserTestSuite, FindsMethodOverrideWhenVirtual) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A {\n"
       "	virtual void foo();\n"
@@ -1560,10 +1541,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsMethodOverrideWhenVirtual) {
       "	void foo();\n"
       "};");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->overrides, L"void B::foo() -> void A::foo() <5:7 5:9>"));
+  EXPECT_THAT(client->overrides, testing::Contains(L"void B::foo() -> void A::foo() <5:7 5:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMultiLayerMethodOverrides) {
+TEST_F(CxxParserTestSuite, FindsMultiLayerMethodOverrides) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A {\n"
       "	virtual void foo();\n"
@@ -1575,11 +1556,11 @@ TEST_F(CxxParserTestSuite, cxxParserFindsMultiLayerMethodOverrides) {
       "	void foo();\n"
       "};");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->overrides, L"void B::foo() -> void A::foo() <5:7 5:9>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->overrides, L"void C::foo() -> void B::foo() <8:7 8:9>"));
+  EXPECT_THAT(client->overrides, testing::Contains(L"void B::foo() -> void A::foo() <5:7 5:9>"));
+  EXPECT_THAT(client->overrides, testing::Contains(L"void C::foo() -> void B::foo() <8:7 8:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMethodOverridesOnDifferentReturnTypes) {
+TEST_F(CxxParserTestSuite, FindsMethodOverridesOnDifferentReturnTypes) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A {\n"
       "	virtual void foo();\n"
@@ -1588,11 +1569,11 @@ TEST_F(CxxParserTestSuite, cxxParserFindsMethodOverridesOnDifferentReturnTypes) 
       "	int foo();\n"
       "};\n");
 
-  EXPECT_TRUE(client->errors.size() == 1);
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->overrides, L"int B::foo() -> void A::foo() <5:6 5:8>"));
+  EXPECT_EQ(client->errors.size(), 1);
+  EXPECT_THAT(client->overrides, testing::Contains(L"int B::foo() -> void A::foo() <5:6 5:8>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNoMethodOverrideWhenNotVirtual) {
+TEST_F(CxxParserTestSuite, FindsNoMethodOverrideWhenNotVirtual) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A {\n"
       "	void foo();\n"
@@ -1601,10 +1582,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNoMethodOverrideWhenNotVirtual) {
       "	void foo();\n"
       "};");
 
-  EXPECT_TRUE(client->overrides.size() == 0);
+  EXPECT_EQ(client->overrides.size(), 0);
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNoMethodOverridesOnDifferentSignatures) {
+TEST_F(CxxParserTestSuite, FindsNoMethodOverridesOnDifferentSignatures) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A {\n"
       "	virtual void foo(int a);\n"
@@ -1613,26 +1594,26 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNoMethodOverridesOnDifferentSignatures)
       "	int foo(int a, int b);\n"
       "};\n");
 
-  EXPECT_TRUE(client->overrides.size() == 0);
+  EXPECT_EQ(client->overrides.size(), 0);
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsingDirectiveDeclInFunctionContext) {
+TEST_F(CxxParserTestSuite, FindsUsingDirectiveDeclInFunctionContext) {
   std::shared_ptr<TestStorage> client = parseCode(
       "void foo()\n"
       "{\n"
       "	using namespace std;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->usages, L"void foo() -> std <3:18 3:20>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"void foo() -> std <3:18 3:20>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsingDirectiveDeclInFileContext) {
+TEST_F(CxxParserTestSuite, FindsUsingDirectiveDeclInFileContext) {
   std::shared_ptr<TestStorage> client = parseCode("using namespace std;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->usages, L"temp.cpp -> std <1:17 1:19>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"temp.cpp -> std <1:17 1:19>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsingDeclInFunctionContext) {
+TEST_F(CxxParserTestSuite, FindsUsingDeclInFunctionContext) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace foo\n"
       "{\n"
@@ -1643,10 +1624,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsingDeclInFunctionContext) {
       "	using foo::a;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->usages, L"void bar() -> foo::a <7:13 7:13>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"void bar() -> foo::a <7:13 7:13>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsingDeclInFileContext) {
+TEST_F(CxxParserTestSuite, FindsUsingDeclInFileContext) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace foo\n"
       "{\n"
@@ -1654,10 +1635,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsingDeclInFileContext) {
       "}\n"
       "using foo::a;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->usages, L"temp.cpp -> foo::a <5:12 5:12>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"temp.cpp -> foo::a <5:12 5:12>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsCallInFunction) {
+TEST_F(CxxParserTestSuite, FindsCallInFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "int sum(int a, int b)\n"
       "{\n"
@@ -1668,10 +1649,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsCallInFunction) {
       "	sum(1, 2);\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"int main() -> int sum(int, int) <7:2 7:4>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"int main() -> int sum(int, int) <7:2 7:4>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsCallInFunctionWithCorrectSignature) {
+TEST_F(CxxParserTestSuite, FindsCallInFunctionWithCorrectSignature) {
   std::shared_ptr<TestStorage> client = parseCode(
       "int sum(int a, int b)\n"
       "{\n"
@@ -1685,10 +1666,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsCallInFunctionWithCorrectSignature) {
       "	sum(1, 2);\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"void func(bool) -> int sum(int, int) <10:2 10:4>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"void func(bool) -> int sum(int, int) <10:2 10:4>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsCallToFunctionWithRightSignature) {
+TEST_F(CxxParserTestSuite, FindsCallToFunctionWithRightSignature) {
   std::shared_ptr<TestStorage> client = parseCode(
       "int sum(int a, int b)\n"
       "{\n"
@@ -1704,11 +1685,11 @@ TEST_F(CxxParserTestSuite, cxxParserFindsCallToFunctionWithRightSignature) {
       "	sum(1.0f, 0.5f);\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"int main() -> int sum(int, int) <11:2 11:4>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"int main() -> float sum(float, float) <12:2 12:4>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"int main() -> int sum(int, int) <11:2 11:4>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"int main() -> float sum(float, float) <12:2 12:4>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsFunctionCallInFunctionParameterList) {
+TEST_F(CxxParserTestSuite, FindsFunctionCallInFunctionParameterList) {
   std::shared_ptr<TestStorage> client = parseCode(
       "int sum(int a, int b)\n"
       "{\n"
@@ -1719,10 +1700,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsFunctionCallInFunctionParameterList) {
       "	return sum(1, sum(2, 3));\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"int main() -> int sum(int, int) <7:16 7:18>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"int main() -> int sum(int, int) <7:16 7:18>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsFunctionCallInMethod) {
+TEST_F(CxxParserTestSuite, FindsFunctionCallInMethod) {
   std::shared_ptr<TestStorage> client = parseCode(
       "int sum(int a, int b)\n"
       "{\n"
@@ -1736,10 +1717,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsFunctionCallInMethod) {
       "	}\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"int App::main() -> int sum(int, int) <9:10 9:12>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"int App::main() -> int sum(int, int) <9:10 9:12>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsImplicitConstructorWithoutDefinitionCall) {
+TEST_F(CxxParserTestSuite, FindsImplicitConstructorWithoutDefinitionCall) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class App\n"
       "{\n"
@@ -1749,10 +1730,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsImplicitConstructorWithoutDefinitionCal
       "	App app;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"int main() -> void App::App() <6:6 6:8>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"int main() -> void App::App() <6:6 6:8>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsExplicitConstructorCall) {
+TEST_F(CxxParserTestSuite, FindsExplicitConstructorCall) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class App\n"
       "{\n"
@@ -1764,10 +1745,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsExplicitConstructorCall) {
       "	App();\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"int main() -> void App::App() <8:2 8:4>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"int main() -> void App::App() <8:2 8:4>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsCallOfExplicitlyDefinedDestructorAtDeleteKeyword) {
+TEST_F(CxxParserTestSuite, FindsCallOfExplicitlyDefinedDestructorAtDeleteKeyword) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class Foo\n"
       "{\n"
@@ -1782,10 +1763,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsCallOfExplicitlyDefinedDestructorAtDele
       "	delete f; \n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"void foo() -> void Foo::~Foo() <11:2 11:7>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"void foo() -> void Foo::~Foo() <11:2 11:7>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsCallOfImplicitlyDefinedDestructorAtDeleteKeyword) {
+TEST_F(CxxParserTestSuite, FindsCallOfImplicitlyDefinedDestructorAtDeleteKeyword) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class Foo\n"
       "{\n"
@@ -1797,10 +1778,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsCallOfImplicitlyDefinedDestructorAtDele
       "	delete f; \n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"void foo() -> void Foo::~Foo() <8:2 8:7>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"void foo() -> void Foo::~Foo() <8:2 8:7>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsExplicitConstructorCallOfField) {
+TEST_F(CxxParserTestSuite, FindsExplicitConstructorCallOfField) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class Item\n"
       "{\n"
@@ -1812,10 +1793,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsExplicitConstructorCallOfField) {
       "	Item item;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"void App::App() -> void Item::Item() <7:10 7:13>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"void App::App() -> void Item::Item() <7:10 7:13>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsFunctionCallInMemberInitialization) {
+TEST_F(CxxParserTestSuite, FindsFunctionCallInMemberInitialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "int one() { return 1; }\n"
       "class Item\n"
@@ -1831,10 +1812,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsFunctionCallInMemberInitialization) {
       "	Item item;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"void App::App() -> int one() <10:10 10:12>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"void App::App() -> int one() <10:10 10:12>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsCopyConstructorCall) {
+TEST_F(CxxParserTestSuite, FindsCopyConstructorCall) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class App\n"
       "{\n"
@@ -1848,10 +1829,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsCopyConstructorCall) {
       "	App app2(app);\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"int main() -> void App::App(const App &) <10:6 10:9>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"int main() -> void App::App(const App &) <10:6 10:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsGlobalVariableConstructorCall) {
+TEST_F(CxxParserTestSuite, FindsGlobalVariableConstructorCall) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class App\n"
       "{\n"
@@ -1860,18 +1841,18 @@ TEST_F(CxxParserTestSuite, cxxParserFindsGlobalVariableConstructorCall) {
       "};\n"
       "App app;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"App app -> void App::App() <6:5 6:7>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"App app -> void App::App() <6:5 6:7>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsGlobalVariableFunctionCall) {
+TEST_F(CxxParserTestSuite, FindsGlobalVariableFunctionCall) {
   std::shared_ptr<TestStorage> client = parseCode(
       "int one() { return 1; }\n"
       "int a = one();\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"int a -> int one() <2:9 2:11>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"int a -> int one() <2:9 2:11>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsOperatorCall) {
+TEST_F(CxxParserTestSuite, FindsOperatorCall) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class App\n"
       "{\n"
@@ -1886,10 +1867,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsOperatorCall) {
       "	app + 2;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"int main() -> void App::operator+(int) <11:6 11:6>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"int main() -> void App::operator+(int) <11:6 11:6>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfFunctionPointer) {
+TEST_F(CxxParserTestSuite, FindsUsageOfFunctionPointer) {
   std::shared_ptr<TestStorage> client = parseCode(
       "void my_int_func(int x)\n"
       "{\n"
@@ -1901,10 +1882,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfFunctionPointer) {
       "	foo = &my_int_func;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->usages, L"void test() -> void my_int_func(int) <8:9 8:19>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"void test() -> void my_int_func(int) <8:9 8:19>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfGlobalVariableInFunction) {
+TEST_F(CxxParserTestSuite, FindsUsageOfGlobalVariableInFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "int bar;\n"
       "\n"
@@ -1913,18 +1894,18 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfGlobalVariableInFunction) {
       "	bar = 1;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->usages, L"int main() -> int bar <5:2 5:4>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"int main() -> int bar <5:2 5:4>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfGlobalVariableInGlobalVariableInitialization) {
+TEST_F(CxxParserTestSuite, FindsUsageOfGlobalVariableInGlobalVariableInitialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "int a = 0;\n"
       "int b[] = {a};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->usages, L"int [] b -> int a <2:12 2:12>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"int [] b -> int a <2:12 2:12>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfGlobalVariableInMethod) {
+TEST_F(CxxParserTestSuite, FindsUsageOfGlobalVariableInMethod) {
   std::shared_ptr<TestStorage> client = parseCode(
       "int bar;\n"
       "\n"
@@ -1936,10 +1917,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfGlobalVariableInMethod) {
       "	}\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->usages, L"void App::foo() -> int bar <7:3 7:5>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"void App::foo() -> int bar <7:3 7:5>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfFieldInMethod) {
+TEST_F(CxxParserTestSuite, FindsUsageOfFieldInMethod) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class App\n"
       "{\n"
@@ -1951,11 +1932,11 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfFieldInMethod) {
       "	int bar;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->usages, L"void App::foo() -> int App::bar <5:3 5:5>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->usages, L"void App::foo() -> int App::bar <6:9 6:11>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"void App::foo() -> int App::bar <5:3 5:5>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"void App::foo() -> int App::bar <6:9 6:11>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfFieldInFunctionCallArguments) {
+TEST_F(CxxParserTestSuite, FindsUsageOfFieldInFunctionCallArguments) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A\n"
       "{\n"
@@ -1967,10 +1948,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfFieldInFunctionCallArguments) {
       "	int bar;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->usages, L"void A::foo(int) -> int A::bar <6:7 6:9>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"void A::foo(int) -> int A::bar <6:7 6:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfFieldInFunctionCallContext) {
+TEST_F(CxxParserTestSuite, FindsUsageOfFieldInFunctionCallContext) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A\n"
       "{\n"
@@ -1982,10 +1963,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfFieldInFunctionCallContext) {
       "	A* a;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->usages, L"void A::foo(int) -> A * A::a <6:3 6:3>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"void A::foo(int) -> A * A::a <6:3 6:3>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfFieldInInitializationList) {
+TEST_F(CxxParserTestSuite, FindsUsageOfFieldInInitializationList) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class App\n"
       "{\n"
@@ -1995,10 +1976,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfFieldInInitializationList) {
       "	int bar;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->usages, L"void App::App() -> int App::bar <4:5 4:7>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"void App::App() -> int App::bar <4:5 4:7>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfMemberInCallExpressionToUnresolvedMemberExpression) {
+TEST_F(CxxParserTestSuite, FindsUsageOfMemberInCallExpressionToUnresolvedMemberExpression) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A {\n"
       "	template <typename T>\n"
@@ -2012,10 +1993,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfMemberInCallExpressionToUnresolv
       "	A a;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->usages, L"T B::run<typename T>() -> A B::a <8:10 8:10>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"T B::run<typename T>() -> A B::a <8:10 8:10>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfMemberInTemporaryObjectExpression) {
+TEST_F(CxxParserTestSuite, FindsUsageOfMemberInTemporaryObjectExpression) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class Foo\n"
       "{\n"
@@ -2037,10 +2018,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfMemberInTemporaryObjectExpressio
       "	const Foo m_i;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->usages, L"void Bar::baba() -> const Foo Bar::m_i <15:7 15:9>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"void Bar::baba() -> const Foo Bar::m_i <15:7 15:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfMemberInDependentScopeMemberExpression) {
+TEST_F(CxxParserTestSuite, FindsUsageOfMemberInDependentScopeMemberExpression) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2053,30 +2034,29 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfMemberInDependentScopeMemberExpr
       "	}\n"
       "};\n");
 
-  EXPECT_TRUE(
-      utility::containsElement<std::wstring>(client->usages, L"void A<typename T>::foo() -> T A<typename T>::m_t <8:3 8:5>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"void A<typename T>::foo() -> T A<typename T>::m_t <8:3 8:5>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsReturnTypeUseInFunction) {
+TEST_F(CxxParserTestSuite, FindsReturnTypeUseInFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "double PI()\n"
       "{\n"
       "	return 3.14159265359;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"double PI() -> double <1:1 1:6>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"double PI() -> double <1:1 1:6>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsParameterTypeUsesInFunction) {
+TEST_F(CxxParserTestSuite, FindsParameterTypeUsesInFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "void ceil(float a)\n"
       "{\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"void ceil(float) -> float <1:11 1:15>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"void ceil(float) -> float <1:11 1:15>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUseOfDecayedParameterTypeInFunction) {
+TEST_F(CxxParserTestSuite, FindsUseOfDecayedParameterTypeInFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template<class T, unsigned int N>\n"
       "class VectorBase\n"
@@ -2085,11 +2065,11 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUseOfDecayedParameterTypeInFunction) {
       "	VectorBase(T values[N]);\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:16> <5:13 5:13>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:32> <5:22 5:22>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:16> <5:13 5:13>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:32> <5:22 5:22>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserUsageOfInjectedTypeInMethodDeclaration) {
+TEST_F(CxxParserTestSuite, UsageOfInjectedTypeInMethodDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class Foo\n"
@@ -2097,46 +2077,44 @@ TEST_F(CxxParserTestSuite, cxxParserUsageOfInjectedTypeInMethodDeclaration) {
       "	Foo& operator=(const Foo&) = delete;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->typeUses,
-      L"Foo<typename T> & Foo<typename T>::operator=(const Foo<typename T> &) -> Foo<typename T> "
-      L"<4:2 4:4>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->typeUses,
-      L"Foo<typename T> & Foo<typename T>::operator=(const Foo<typename T> &) -> Foo<typename T> "
-      L"<4:23 4:25>"));
+  EXPECT_THAT(client->typeUses,
+              testing::Contains(L"Foo<typename T> & Foo<typename T>::operator=(const Foo<typename T> &) -> Foo<typename T> "
+                                L"<4:2 4:4>"));
+  EXPECT_THAT(client->typeUses,
+              testing::Contains(L"Foo<typename T> & Foo<typename T>::operator=(const Foo<typename T> &) -> Foo<typename T> "
+                                L"<4:23 4:25>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUseOfQualifiedTypeInFunction) {
+TEST_F(CxxParserTestSuite, FindsUseOfQualifiedTypeInFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "void test(const int t)\n"
       "{\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"void test(const int) -> int <1:17 1:19>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"void test(const int) -> int <1:17 1:19>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsParameterTypeUsesInConstructor) {
+TEST_F(CxxParserTestSuite, FindsParameterTypeUsesInConstructor) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A\n"
       "{\n"
       "	A(int a);\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"void A::A(int) -> int <3:4 3:6>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"void A::A(int) -> int <3:4 3:6>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeUsesInFunctionBody) {
+TEST_F(CxxParserTestSuite, FindsTypeUsesInFunctionBody) {
   std::shared_ptr<TestStorage> client = parseCode(
       "int main()\n"
       "{\n"
       "	int a = 42;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> int <3:2 3:4>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> int <3:2 3:4>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeUsesInMethodBody) {
+TEST_F(CxxParserTestSuite, FindsTypeUsesInMethodBody) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A\n"
       "{\n"
@@ -2147,10 +2125,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypeUsesInMethodBody) {
       "	}\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int A::main() -> int <5:3 5:5>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int A::main() -> int <5:3 5:5>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeUsesInLoopsAndConditions) {
+TEST_F(CxxParserTestSuite, FindsTypeUsesInLoopsAndConditions) {
   std::shared_ptr<TestStorage> client = parseCode(
       "int main()\n"
       "{\n"
@@ -2164,12 +2142,12 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypeUsesInLoopsAndConditions) {
       "	}\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> int <5:3 5:5>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> int <7:7 7:9>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> int <9:3 9:5>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> int <5:3 5:5>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> int <7:7 7:9>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> int <9:3 9:5>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeUsesOfBaseClassInDerivedConstructor) {
+TEST_F(CxxParserTestSuite, FindsTypeUsesOfBaseClassInDerivedConstructor) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A\n"
       "{\n"
@@ -2182,10 +2160,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypeUsesOfBaseClassInDerivedConstructor
       "	B() : A(42) {}\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"void B::B() -> A <9:8 9:8>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"void B::B() -> A <9:8 9:8>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsEnumUsesInGlobalSpace) {
+TEST_F(CxxParserTestSuite, FindsEnumUsesInGlobalSpace) {
   std::shared_ptr<TestStorage> client = parseCode(
       "enum A\n"
       "{\n"
@@ -2195,13 +2173,13 @@ TEST_F(CxxParserTestSuite, cxxParserFindsEnumUsesInGlobalSpace) {
       "A a = B;\n"
       "A* aPtr = new A;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->usages, L"A a -> A::B <6:7 6:7>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A a -> A <6:1 6:1>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A * aPtr -> A <7:1 7:1>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A * aPtr -> A <7:15 7:15>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"A a -> A::B <6:7 6:7>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A a -> A <6:1 6:1>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A * aPtr -> A <7:1 7:1>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A * aPtr -> A <7:15 7:15>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsEnumUsesInFunctionBody) {
+TEST_F(CxxParserTestSuite, FindsEnumUsesInFunctionBody) {
   std::shared_ptr<TestStorage> client = parseCode(
       "enum A\n"
       "{\n"
@@ -2214,13 +2192,13 @@ TEST_F(CxxParserTestSuite, cxxParserFindsEnumUsesInFunctionBody) {
       "	A* aPtr = new A;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->usages, L"int main() -> A::B <8:8 8:8>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> A <8:2 8:2>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> A <9:2 9:2>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> A <9:16 9:16>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"int main() -> A::B <8:8 8:8>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> A <8:2 8:2>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> A <9:2 9:2>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> A <9:16 9:16>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfTemplateParameterOfTemplateMemberVariableDeclaration) {
+TEST_F(CxxParserTestSuite, FindsUsageOfTemplateParameterOfTemplateMemberVariableDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "struct IsBaseType {\n"
@@ -2229,14 +2207,14 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfTemplateParameterOfTemplateMembe
       "template <typename T>\n"
       "const bool IsBaseType<T>::value;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:20> <1:20 1:20>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(    // TODO: fix FAIL because usage in name
-                                                         // qualifier is not recorded
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:20> <1:20 1:20>"));
+  EXPECT_THAT(    // TODO: fix FAIL because usage in name
+                  // qualifier is not recorded
       client->localSymbols,
-      L"temp.cpp<5:20> <5:20 5:20>"));
+      testing::Contains(L"temp.cpp<5:20> <5:20 5:20>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfTemplateParametersWithDifferentDepthOfTemplateFunction) {
+TEST_F(CxxParserTestSuite, FindsUsageOfTemplateParametersWithDifferentDepthOfTemplateFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2249,11 +2227,11 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfTemplateParametersWithDifferentD
       "	}\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:20> <7:3 7:3>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<4:21> <5:11 5:11>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:20> <7:3 7:3>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<4:21> <5:11 5:11>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfTemplateParametersWithDifferentDepthOfPartialClassTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsUsageOfTemplateParametersWithDifferentDepthOfPartialClassTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2271,8 +2249,8 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfTemplateParametersWithDifferentD
       "	};\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:20> <13:3 13:3>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<10:21> <13:9 13:9>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:20> <13:3 13:3>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<10:21> <13:9 13:9>"));
 }
 
 TEST_F(CxxParserTestSuite,
@@ -2288,10 +2266,10 @@ TEST_F(CxxParserTestSuite,
       "	{}\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<4:36> <7:11 7:11>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<4:36> <7:11 7:11>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfTemplateTemplateParameterOfTemplateClassExplicitlyInstantiatedWithTemplateType) {
+TEST_F(CxxParserTestSuite, FindsUsageOfTemplateTemplateParameterOfTemplateClassExplicitlyInstantiatedWithTemplateType) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2304,10 +2282,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfTemplateTemplateParameterOfTempl
       "	{}\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<4:36> <8:11 8:11>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<4:36> <8:11 8:11>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypedefInOtherClassThatDependsOnOwnTemplateParameter) {
+TEST_F(CxxParserTestSuite, FindsTypedefInOtherClassThatDependsOnOwnTemplateParameter) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2323,14 +2301,13 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypedefInOtherClassThatDependsOnOwnTemp
       "};\n"
       "B<int>::type f = 0;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<int>::type -> int <5:10 5:10>"));
-  EXPECT_TRUE(
-      utility::containsElement<std::wstring>(client->typeUses, L"B<typename U>::type -> A<typename T>::type <11:25 11:28>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"B<int>::type -> A<int>::type <11:25 11:28>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"B<int>::type f -> B<int>::type <13:9 13:12>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<int>::type -> int <5:10 5:10>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"B<typename U>::type -> A<typename T>::type <11:25 11:28>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"B<int>::type -> A<int>::type <11:25 11:28>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"B<int>::type f -> B<int>::type <13:9 13:12>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfTemplateParameterInQualifierOfOtherSymbol) {
+TEST_F(CxxParserTestSuite, FindsUsageOfTemplateParameterInQualifierOfOtherSymbol) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "struct find_if_impl;\n"
@@ -2342,10 +2319,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfTemplateParameterInQualifierOfOt
       "	using f = typename find_if_impl<S>::template f<R::template f, Ts...>;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<4:20> <8:49 8:49>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<4:20> <8:49 8:49>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUseOfDependentTemplateSpecializationType) {
+TEST_F(CxxParserTestSuite, FindsUseOfDependentTemplateSpecializationType) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2362,12 +2339,11 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUseOfDependentTemplateSpecializationTyp
       "};\n"
       "B<bool>::type f = 0.0f;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->typeUses, L"B<typename U>::type -> A<typename T>::type<float> <12:10 12:17>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"B<bool>::type f -> B<bool>::type <14:10 14:13>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"B<typename U>::type -> A<typename T>::type<float> <12:10 12:17>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"B<bool>::type f -> B<bool>::type <14:10 14:13>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserCreatesSingleNodeForAllPossibleParameterPackExpansionsOfTemplateFunction) {
+TEST_F(CxxParserTestSuite, CreatesSingleNodeForAllPossibleParameterPackExpansionsOfTemplateFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template<typename T>\n"
       "T adder(T v) { return v; }\n"
@@ -2377,13 +2353,11 @@ TEST_F(CxxParserTestSuite, cxxParserCreatesSingleNodeForAllPossibleParameterPack
       "\n"
       "void foo() { long sum = adder(1, 2, 3, 8, 7); }\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->functions, L"int adder<int, <...>>(int, ...) <5:1 <5:1 <5:3 5:7> 5:30> 5:65>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->calls, L"int adder<int, <...>>(int, ...) -> int adder<int, <...>>(int, ...) <5:49 5:53>"));
+  EXPECT_THAT(client->functions, testing::Contains(L"int adder<int, <...>>(int, ...) <5:1 <5:1 <5:3 5:7> 5:30> 5:65>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"int adder<int, <...>>(int, ...) -> int adder<int, <...>>(int, ...) <5:49 5:53>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateArgumentOfExplicitTemplateInstantiation) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateArgumentOfExplicitTemplateInstantiation) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2395,11 +2369,11 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateArgumentOfExplicitTemplateI
       "	return 0;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<int> -> int <7:4 7:6>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> int <7:4 7:6>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<int> -> int <7:4 7:6>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> int <7:4 7:6>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateArgumentOfExplicitTemplateInstantiatedWithFunctionPrototype) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateArgumentOfExplicitTemplateInstantiatedWithFunctionPrototype) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2410,12 +2384,12 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateArgumentOfExplicitTemplateI
       "	A<int()> a;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<int()> -> int <7:4 7:6>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"void foo() -> int <7:4 7:6>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"void foo() -> int <7:4 7:6>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<int()> -> int <7:4 7:6>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"void foo() -> int <7:4 7:6>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"void foo() -> int <7:4 7:6>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateArgumentForParameterPackOfExplicitTemplateInstantiation) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateArgumentForParameterPackOfExplicitTemplateInstantiation) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename... T>\n"
       "class A\n"
@@ -2426,15 +2400,15 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateArgumentForParameterPackOfE
       "   A<int, float>();\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<<...>> -> int <7:6 7:8>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<<...>> -> float <7:11 7:15>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> int <7:6 7:8>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> float <7:11 7:15>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> int <7:6 7:8>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> float <7:11 7:15>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<<...>> -> int <7:6 7:8>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<<...>> -> float <7:11 7:15>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> int <7:6 7:8>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> float <7:11 7:15>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> int <7:6 7:8>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> float <7:11 7:15>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateArgumentInNonDefaultConstructorOfExplicitTemplateInstantiation) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateArgumentInNonDefaultConstructorOfExplicitTemplateInstantiation) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2447,12 +2421,12 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateArgumentInNonDefaultConstru
       "	A<int>(5);\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<int> -> int <9:4 9:6>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> int <9:4 9:6>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> int <9:4 9:6>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<int> -> int <9:4 9:6>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> int <9:4 9:6>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> int <9:4 9:6>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateArgumentInDefaultConstructorOfExplicitTemplateInstantiation) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateArgumentInDefaultConstructorOfExplicitTemplateInstantiation) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2465,12 +2439,12 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateArgumentInDefaultConstructo
       "	A<int>();\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<int> -> int <9:4 9:6>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> int <9:4 9:6>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> int <9:4 9:6>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<int> -> int <9:4 9:6>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> int <9:4 9:6>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> int <9:4 9:6>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateArgumentInNewExpressionOfExplicitTemplateInstantiation) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateArgumentInNewExpressionOfExplicitTemplateInstantiation) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2483,12 +2457,12 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateArgumentInNewExpressionOfEx
       "	new A<int>();\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<int> -> int <9:8 9:10>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> int <9:8 9:10>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> int <9:8 9:10>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<int> -> int <9:8 9:10>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> int <9:8 9:10>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> int <9:8 9:10>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNoTemplateArgumentForBuiltinNonTypeIntTemplateParameterOfExplicitTemplateInstantiation) {
+TEST_F(CxxParserTestSuite, FindsNoTemplateArgumentForBuiltinNonTypeIntTemplateParameterOfExplicitTemplateInstantiation) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <int T>\n"    // use of "int"
       "class A\n"
@@ -2500,10 +2474,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNoTemplateArgumentForBuiltinNonTypeIntT
       "	return 0;\n"
       "}\n");
 
-  EXPECT_TRUE(client->typeUses.size() == 3);
+  EXPECT_EQ(client->typeUses.size(), 3);
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNoTemplateArgumentForBuiltinNonTypeBoolTemplateParameterOfExplicitTemplateInstantiation) {
+TEST_F(CxxParserTestSuite, FindsNoTemplateArgumentForBuiltinNonTypeBoolTemplateParameterOfExplicitTemplateInstantiation) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <bool T>\n"    // use of "bool"
       "class A\n"
@@ -2515,10 +2489,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNoTemplateArgumentForBuiltinNonTypeBool
       "	return 0;\n"
       "}\n");
 
-  EXPECT_TRUE(client->typeUses.size() == 3);
+  EXPECT_EQ(client->typeUses.size(), 3);
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeCustomPointerTemplateArgumentOfImplicitTemplateInstantiation) {
+TEST_F(CxxParserTestSuite, FindsNonTypeCustomPointerTemplateArgumentOfImplicitTemplateInstantiation) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class P\n"
       "{};\n"
@@ -2531,10 +2505,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeCustomPointerTemplateArgumentOfI
       "	A<&g_p> a;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<&g_p> -> P g_p <9:5 9:7>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<&g_p> -> P g_p <9:5 9:7>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeCustomReferenceTemplateArgumentOfImplicitTemplateInstantiation) {
+TEST_F(CxxParserTestSuite, FindsNonTypeCustomReferenceTemplateArgumentOfImplicitTemplateInstantiation) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class P\n"
       "{};\n"
@@ -2547,7 +2521,7 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeCustomReferenceTemplateArgumentO
       "	A<g_p> a;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<g_p> -> P g_p <9:4 9:6>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<g_p> -> P g_p <9:4 9:6>"));
 }
 
 TEST_F(CxxParserTestSuite,
@@ -2562,10 +2536,10 @@ TEST_F(CxxParserTestSuite,
       "   A<1, 2, 33>();\n"    // use of "A"
       "}\n");
 
-  EXPECT_TRUE(client->typeUses.size() == 3);
+  EXPECT_EQ(client->typeUses.size(), 3);
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateTemplateArgumentOfExplicitTemplateInstantiation) {
+TEST_F(CxxParserTestSuite, FindsTemplateTemplateArgumentOfExplicitTemplateInstantiation) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2578,11 +2552,11 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateTemplateArgumentOfExplicitTempl
       "	B<A> ba;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"B<A> -> A<typename T> <9:4 9:4>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> A<typename T> <9:4 9:4>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"B<A> -> A<typename T> <9:4 9:4>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> A<typename T> <9:4 9:4>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateTemplateArgumentForParameterPackOfExplicitTemplateInstantiation) {
+TEST_F(CxxParserTestSuite, FindsTemplateTemplateArgumentForParameterPackOfExplicitTemplateInstantiation) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2597,13 +2571,13 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateTemplateArgumentForParameterPac
       "	B<A, A>();\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"B<<...>> -> A<typename T> <11:4 11:4>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"B<<...>> -> A<typename T> <11:7 11:7>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> A<typename T> <11:4 11:4>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> A<typename T> <11:7 11:7>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"B<<...>> -> A<typename T> <11:4 11:4>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"B<<...>> -> A<typename T> <11:7 11:7>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> A<typename T> <11:4 11:4>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> A<typename T> <11:7 11:7>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateArgumentForImplicitSpecializationOfGlobalTemplateVariable) {
+TEST_F(CxxParserTestSuite, FindsTemplateArgumentForImplicitSpecializationOfGlobalTemplateVariable) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "T v;\n"
@@ -2612,11 +2586,11 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateArgumentForImplicitSpecializati
       "	v<int> = 9;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int v<int> -> int <5:4 5:6>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"void test() -> int <5:4 5:6>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int v<int> -> int <5:4 5:6>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"void test() -> int <5:4 5:6>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateMemberSpecializationForMethodOfImplicitTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsTemplateMemberSpecializationForMethodOfImplicitTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2629,11 +2603,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateMemberSpecializationForMethodOf
       "	A<int> a;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->templateSpecializations, L"int A<int>::foo() -> T A<typename T>::foo() <5:4 5:6>"));
+  EXPECT_THAT(client->templateSpecializations, testing::Contains(L"int A<int>::foo() -> T A<typename T>::foo() <5:4 5:6>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateMemberSpecializationForStaticVariableOfImplicitTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsTemplateMemberSpecializationForStaticVariableOfImplicitTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2646,11 +2619,11 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateMemberSpecializationForStaticVa
       "	A<int> a;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->templateSpecializations, L"static int A<int>::foo -> static T A<typename T>::foo <5:11 5:13>"));
+  EXPECT_THAT(
+      client->templateSpecializations, testing::Contains(L"static int A<int>::foo -> static T A<typename T>::foo <5:11 5:13>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateMemberSpecializationForFieldOfImplicitTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsTemplateMemberSpecializationForFieldOfImplicitTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2663,11 +2636,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateMemberSpecializationForFieldOfI
       "	A<int> a;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->templateSpecializations, L"int A<int>::foo -> T A<typename T>::foo <5:4 5:6>"));
+  EXPECT_THAT(client->templateSpecializations, testing::Contains(L"int A<int>::foo -> T A<typename T>::foo <5:4 5:6>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateMemberSpecializationForFieldOfMemberClassOfImplicitTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsTemplateMemberSpecializationForFieldOfMemberClassOfImplicitTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2683,11 +2655,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateMemberSpecializationForFieldOfM
       "	A<int>::B b;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->templateSpecializations, L"int A<int>::B::foo -> T A<typename T>::B::foo <7:5 7:7>"));
+  EXPECT_THAT(client->templateSpecializations, testing::Contains(L"int A<int>::B::foo -> T A<typename T>::B::foo <7:5 7:7>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateMemberSpecializationForMemberClassOfImplicitTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsTemplateMemberSpecializationForMemberClassOfImplicitTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2700,10 +2671,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateMemberSpecializationForMemberCl
       "	A<int> a;\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->templateSpecializations, L"A<int>::B -> A<typename T>::B <5:8 5:8>"));
+  EXPECT_THAT(client->templateSpecializations, testing::Contains(L"A<int>::B -> A<typename T>::B <5:8 5:8>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateArgumentOfExplicitTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateArgumentOfExplicitTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2714,10 +2685,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateArgumentOfExplicitTemplateS
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<int> -> int <6:9 6:11>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<int> -> int <6:9 6:11>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNoTemplateArgumentForBuiltinNonTypeIntTemplateParameterOfExplicitTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsNoTemplateArgumentForBuiltinNonTypeIntTemplateParameterOfExplicitTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <int T>\n"    // use of "int"
       "class A\n"
@@ -2728,10 +2699,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNoTemplateArgumentForBuiltinNonTypeIntT
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(client->typeUses.size() == 1);
+  EXPECT_EQ(client->typeUses.size(), 1);
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNoTemplateArgumentForBuiltinNonTypeBoolTemplateParameterOfExplicitTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsNoTemplateArgumentForBuiltinNonTypeBoolTemplateParameterOfExplicitTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <bool T>\n"    // use of "bool"
       "class A\n"
@@ -2742,10 +2713,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNoTemplateArgumentForBuiltinNonTypeBool
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(client->typeUses.size() == 1);
+  EXPECT_EQ(client->typeUses.size(), 1);
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeCustomPointerTemplateArgumentOfExplicitTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsNonTypeCustomPointerTemplateArgumentOfExplicitTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class P\n"
       "{};\n"
@@ -2758,10 +2729,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeCustomPointerTemplateArgumentOfE
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<&g_p> -> P g_p <8:10 8:12>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<&g_p> -> P g_p <8:10 8:12>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeCustomReferenceTemplateArgumentOfExplicitTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsNonTypeCustomReferenceTemplateArgumentOfExplicitTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class P\n"
       "{};\n"
@@ -2774,10 +2745,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNonTypeCustomReferenceTemplateArgumentO
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<g_p> -> P g_p <8:9 8:11>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<g_p> -> P g_p <8:9 8:11>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateTemplateArgumentOfExplicitTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsTemplateTemplateArgumentOfExplicitTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2790,10 +2761,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateTemplateArgumentOfExplicitTempl
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"B<A> -> A<typename T> <8:9 8:9>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"B<A> -> A<typename T> <8:9 8:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateArgumentsOfExplicitPartialClassTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateArgumentsOfExplicitPartialClassTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T, typename U>\n"
       "class A\n"
@@ -2804,8 +2775,8 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateArgumentsOfExplicitPartialC
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<5:20> <6:9 6:9>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<typename T, int> -> int <6:12 6:14>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<5:20> <6:9 6:9>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<typename T, int> -> int <6:12 6:14>"));
 }
 
 TEST_F(CxxParserTestSuite,
@@ -2820,7 +2791,7 @@ TEST_F(CxxParserTestSuite,
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<5:15> <6:12 6:12>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<5:15> <6:12 6:12>"));
 }
 
 TEST_F(CxxParserTestSuite,
@@ -2835,7 +2806,7 @@ TEST_F(CxxParserTestSuite,
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<5:16> <6:15 6:15>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<5:16> <6:15 6:15>"));
 }
 
 TEST_F(CxxParserTestSuite,
@@ -2852,11 +2823,11 @@ TEST_F(CxxParserTestSuite,
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->typeUses, L"A<&g_p, q> -> P g_p <8:10 8:12>"    // TODO: this is completely wrong?
-                                                              // should be a normal usage
-      ));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<7:14> <8:15 8:15>"));
+  EXPECT_THAT(client->typeUses,
+              testing::Contains(L"A<&g_p, q> -> P g_p <8:10 8:12>"    // TODO: this is completely wrong?
+                                                                      // should be a normal usage
+                                ));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<7:14> <8:15 8:15>"));
 }
 
 TEST_F(CxxParserTestSuite,
@@ -2873,11 +2844,11 @@ TEST_F(CxxParserTestSuite,
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<g_p, q> -> P g_p <8:9 8:11>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<7:14> <8:14 8:14>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<g_p, q> -> P g_p <8:9 8:11>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<7:14> <8:14 8:14>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateArgumentForTemplateTemplateParameterOfExplicitPartialClassTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsTemplateArgumentForTemplateTemplateParameterOfExplicitPartialClassTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2890,9 +2861,8 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateArgumentForTemplateTemplatePara
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->typeUses, L"B<A, template<typename> typename U> -> A<typename T> <8:9 8:9>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<7:36> <8:12 8:12>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"B<A, template<typename> typename U> -> A<typename T> <8:9 8:9>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<7:36> <8:12 8:12>"));
 }
 
 TEST_F(CxxParserTestSuite,
@@ -2907,7 +2877,7 @@ TEST_F(CxxParserTestSuite,
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<5:27> <6:16 6:17>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<5:27> <6:16 6:17>"));
 }
 
 TEST_F(CxxParserTestSuite,
@@ -2922,11 +2892,11 @@ TEST_F(CxxParserTestSuite,
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<5:36> <6:12 6:13>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<5:48> <6:16 6:17>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<5:36> <6:12 6:13>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<5:48> <6:16 6:17>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsImplicitTemplateClassSpecialization) {
+TEST_F(CxxParserTestSuite, FindsImplicitTemplateClassSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2936,10 +2906,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsImplicitTemplateClassSpecialization) {
       "\n"
       "A<int> a;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->templateSpecializations, L"A<int> -> A<typename T> <2:7 2:7>"));
+  EXPECT_THAT(client->templateSpecializations, testing::Contains(L"A<int> -> A<typename T> <2:7 2:7>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsClassInheritanceFromImplicitTemplateClassSpecialization) {
+TEST_F(CxxParserTestSuite, FindsClassInheritanceFromImplicitTemplateClassSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2951,7 +2921,7 @@ TEST_F(CxxParserTestSuite, cxxParserFindsClassInheritanceFromImplicitTemplateCla
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->inheritances, L"B -> A<int> <7:17 7:17>"));
+  EXPECT_THAT(client->inheritances, testing::Contains(L"B -> A<int> <7:17 7:17>"));
 }
 
 // TODO(Hussein): Fix the test case
@@ -2970,7 +2940,7 @@ TEST_F(CxxParserTestSuite, DISABLED_recordBaseClassOfImplicitTemplateClassSpecia
   EXPECT_THAT(client->inheritances, testing::Contains(testing::StrEq(L"Vector2<float> -> VectorBase<float, 2> <5:24 5:33>")));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateClassSpecializationWithTemplateArgument) {
+TEST_F(CxxParserTestSuite, FindsTemplateClassSpecializationWithTemplateArgument) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -2983,24 +2953,23 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateClassSpecializationWithTemplate
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<7:20> <8:19 8:19>"));
-  EXPECT_TRUE(client->inheritances.size() == 1);
-  EXPECT_TRUE(client->classes.size() == 2);
-  EXPECT_TRUE(client->fields.size() == 1);
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<7:20> <8:19 8:19>"));
+  EXPECT_EQ(client->inheritances.size(), 1);
+  EXPECT_EQ(client->classes.size(), 2);
+  EXPECT_EQ(client->fields.size(), 1);
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsCorrectOrderOfTemplateArgumentsForExplicitClassTemplateSpecialization) {
+TEST_F(CxxParserTestSuite, FindsCorrectOrderOfTemplateArgumentsForExplicitClassTemplateSpecialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T1, typename T2, typename T3>\n"
       "class vector { };\n"
       "template<class Foo1, class Foo2>\n"
       "class vector<Foo2, Foo1, int> { };\n");
 
-  EXPECT_TRUE(
-      utility::containsElement<std::wstring>(client->classes, L"vector<class Foo2, class Foo1, int> <3:1 <4:7 4:12> 4:33>"));
+  EXPECT_THAT(client->classes, testing::Contains(L"vector<class Foo2, class Foo1, int> <3:1 <4:7 4:12> 4:33>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserReplacesDependentTemplateArgumentsOfExplicitTemplateSpecializationWithNameOfBaseTemplate) {
+TEST_F(CxxParserTestSuite, ReplacesDependentTemplateArgumentsOfExplicitTemplateSpecializationWithNameOfBaseTemplate) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A {};\n"
@@ -3009,10 +2978,10 @@ TEST_F(CxxParserTestSuite, cxxParserReplacesDependentTemplateArgumentsOfExplicit
       "template<class Foo1>\n"
       "class vector<Foo1, A<Foo1>> { };\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->classes, L"vector<class Foo1, A<typename T>> <5:1 <6:7 6:12> 6:31>"));
+  EXPECT_THAT(client->classes, testing::Contains(L"vector<class Foo1, A<typename T>> <5:1 <6:7 6:12> 6:31>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserReplacesUnknownTemplateArgumentsOfExplicitTemplateSpecializationWithDepthAndPositionIndex) {
+TEST_F(CxxParserTestSuite, ReplacesUnknownTemplateArgumentsOfExplicitTemplateSpecializationWithDepthAndPositionIndex) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T0>\n"
       "class foo {\n"
@@ -3022,11 +2991,10 @@ TEST_F(CxxParserTestSuite, cxxParserReplacesUnknownTemplateArgumentsOfExplicitTe
       "	class vector<T0, T1> { };\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->classes, L"foo<typename T0>::vector<arg0_0, class T1> <5:2 <6:8 6:13> 6:25>"));
+  EXPECT_THAT(client->classes, testing::Contains(L"foo<typename T0>::vector<arg0_0, class T1> <5:2 <6:8 6:13> 6:25>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateClassConstructorUsageOfField) {
+TEST_F(CxxParserTestSuite, FindsTemplateClassConstructorUsageOfField) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -3035,11 +3003,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateClassConstructorUsageOfField) {
       "	T foo;\n"
       "};\n");
 
-  EXPECT_TRUE(
-      utility::containsElement<std::wstring>(client->usages, L"void A<typename T>::A<T>() -> T A<typename T>::foo <4:7 4:9>"));
+  EXPECT_THAT(client->usages, testing::Contains(L"void A<typename T>::A<T>() -> T A<typename T>::foo <4:7 4:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsCorrectMethodReturnTypeOfTemplateClassInDeclaration) {
+TEST_F(CxxParserTestSuite, FindsCorrectMethodReturnTypeOfTemplateClassInDeclaration) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -3047,33 +3014,33 @@ TEST_F(CxxParserTestSuite, cxxParserFindsCorrectMethodReturnTypeOfTemplateClassI
       "	T foo();\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<1:20> <4:2 4:2>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<1:20> <4:2 4:2>"));
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->methods, L"private T A<typename T>::foo() <4:2 <4:4 4:6> 4:8>"));
+  EXPECT_THAT(client->methods, testing::Contains(L"private T A<typename T>::foo() <4:2 <4:4 4:6> 4:8>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateDefaultArgumentTypeOfTemplateClass) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateDefaultArgumentTypeOfTemplateClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T = int>\n"
       "class A\n"
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"A<typename T> -> int <1:24 1:26>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"A<typename T> -> int <1:24 1:26>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNoDefaultArgumentTypeForNonTypeBoolTemplateParameterOfTemplateClass) {
+TEST_F(CxxParserTestSuite, FindsNoDefaultArgumentTypeForNonTypeBoolTemplateParameterOfTemplateClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <bool T = true>\n"
       "class A\n"
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(client->typeUses.size() == 1);
+  EXPECT_EQ(client->typeUses.size(), 1);
   ;    // only the "bool" type is recorded and nothing for the default arg
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateTemplateDefaultArgumentTypeOfTemplateClass) {
+TEST_F(CxxParserTestSuite, FindsTemplateTemplateDefaultArgumentTypeOfTemplateClass) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -3082,11 +3049,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateTemplateDefaultArgumentTypeOfTe
       "class B\n"
       "{};\n");
 
-  EXPECT_TRUE(
-      utility::containsElement<std::wstring>(client->typeUses, L"B<template<typename> typename T> -> A<typename T> <4:40 4:40>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"B<template<typename> typename T> -> A<typename T> <4:40 4:40>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsImplicitInstantiationOfTemplateFunction) {
+TEST_F(CxxParserTestSuite, FindsImplicitInstantiationOfTemplateFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "T test(T a)\n"
@@ -3099,11 +3065,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsImplicitInstantiationOfTemplateFunction
       "	return test(1);\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->templateSpecializations, L"int test<int>(int) -> T test<typename T>(T) <2:3 2:6>"));
+  EXPECT_THAT(client->templateSpecializations, testing::Contains(L"int test<int>(int) -> T test<typename T>(T) <2:3 2:6>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsExplicitSpecializationOfTemplateFunction) {
+TEST_F(CxxParserTestSuite, FindsExplicitSpecializationOfTemplateFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "T test(T a)\n"
@@ -3117,11 +3082,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsExplicitSpecializationOfTemplateFunctio
       "	return a + a;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->templateSpecializations, L"int test<int>(int) -> T test<typename T>(T) <8:5 8:8>"));
+  EXPECT_THAT(client->templateSpecializations, testing::Contains(L"int test<int>(int) -> T test<typename T>(T) <8:5 8:8>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsExplicitTypeTemplateArgumentOfExplicitInstantiationOfTemplateFunction) {
+TEST_F(CxxParserTestSuite, FindsExplicitTypeTemplateArgumentOfExplicitInstantiationOfTemplateFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "void test()\n"
@@ -3133,10 +3097,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsExplicitTypeTemplateArgumentOfExplicitI
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"void test<int>() -> int <7:11 7:13>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"void test<int>() -> int <7:11 7:13>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsExplicitTypeTemplateArgumentOfFunctionCallInFunction) {
+TEST_F(CxxParserTestSuite, FindsExplicitTypeTemplateArgumentOfFunctionCallInFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "void test(){}\n"
@@ -3147,10 +3111,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsExplicitTypeTemplateArgumentOfFunctionC
       "	return 1;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"void test<int>() -> int <6:7 6:9>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"void test<int>() -> int <6:7 6:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNoExplicitNonTypeIntTemplateArgumentOfFunctionCallInFunction) {
+TEST_F(CxxParserTestSuite, FindsNoExplicitNonTypeIntTemplateArgumentOfFunctionCallInFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <int T>\n"    // use of "int"
       "void test(){}\n"       // 2x use of "void"
@@ -3161,10 +3125,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNoExplicitNonTypeIntTemplateArgumentOfF
       "	return 1;\n"
       "};\n");
 
-  EXPECT_TRUE(client->typeUses.size() == 4);
+  EXPECT_EQ(client->typeUses.size(), 4);
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsExplicitTemplateTemplateArgumentOfFunctionCallInFunction) {
+TEST_F(CxxParserTestSuite, FindsExplicitTemplateTemplateArgumentOfFunctionCallInFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A {};\n"
@@ -3176,10 +3140,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsExplicitTemplateTemplateArgumentOfFunct
       "	return 1;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"void test<A>() -> A<typename T> <7:7 7:7>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"void test<A>() -> A<typename T> <7:7 7:7>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNoImplicitTypeTemplateArgumentOfFunctionCallInFunction) {
+TEST_F(CxxParserTestSuite, FindsNoImplicitTypeTemplateArgumentOfFunctionCallInFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "void test(T data){}\n"    // 2x use of "void" + 1x use of "int"
@@ -3190,10 +3154,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNoImplicitTypeTemplateArgumentOfFunctio
       "	return 1;\n"
       "};\n");
 
-  EXPECT_TRUE(client->typeUses.size() == 4);
+  EXPECT_EQ(client->typeUses.size(), 4);
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsExplicitTypeTemplateArgumentOfFunctionCallInVarDecl) {
+TEST_F(CxxParserTestSuite, FindsExplicitTypeTemplateArgumentOfFunctionCallInVarDecl) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "T test(){ return 1; }\n"
@@ -3203,10 +3167,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsExplicitTypeTemplateArgumentOfFunctionC
       "	int foo = test<int>();\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int test<int>() -> int <6:17 6:19>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int test<int>() -> int <6:17 6:19>"));
 }
 
-TEST_F(CxxParserTestSuite, CxxParserFindsNoImplicitTypeTemplateArgumentOfFunctionCallInVarDecl) {
+TEST_F(CxxParserTestSuite, FindsNoImplicitTypeTemplateArgumentOfFunctionCallInVarDecl) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "T test(T i){ return i; }\n"    // 2x use of "int"
@@ -3216,10 +3180,10 @@ TEST_F(CxxParserTestSuite, CxxParserFindsNoImplicitTypeTemplateArgumentOfFunctio
       "	int foo = test(1);\n"    // usage of "int"
       "};\n");
 
-  EXPECT_TRUE(client->typeUses.size() == 3);
+  EXPECT_EQ(client->typeUses.size(), 3);
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateDefaultArgumentTypeOfTemplateFunction) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateDefaultArgumentTypeOfTemplateFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T = int>\n"
       "void test()\n"
@@ -3232,21 +3196,21 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateDefaultArgumentTypeOfTempla
       "	return 1;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"void test<typename T>() -> int <1:24 1:26>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"void test<typename T>() -> int <1:24 1:26>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserDoesNotFindDefaultArgumentTypeForNonTypeBoolTemplateParameterOfTemplateFunction) {
+TEST_F(CxxParserTestSuite, DoesNotFindDefaultArgumentTypeForNonTypeBoolTemplateParameterOfTemplateFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <bool T = true>\n"
       "void test()\n"
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(client->typeUses.size() == 2);
+  EXPECT_EQ(client->typeUses.size(), 2);
   ;    // only "bool" and "void" is recorded
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateTemplateDefaultArgumentTypeOfTemplateFunction) {
+TEST_F(CxxParserTestSuite, FindsTemplateTemplateDefaultArgumentTypeOfTemplateFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class A\n"
@@ -3256,11 +3220,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateTemplateDefaultArgumentTypeOfTe
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->typeUses, L"void test<template<typename> typename T>() -> A<typename T> <4:40 4:40>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"void test<template<typename> typename T>() -> A<typename T> <4:40 4:40>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsLambdaCallingAFunction) {
+TEST_F(CxxParserTestSuite, FindsLambdaCallingAFunction) {
   std::shared_ptr<TestStorage> client = parseCode(
       "void func() {}\n"
       "void lambdaCaller()\n"
@@ -3271,11 +3234,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsLambdaCallingAFunction) {
       "	}();\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(
-      client->calls, L"void lambdaCaller::lambda at 4:2() const -> void func() <6:3 6:6>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"void lambdaCaller::lambda at 4:2() const -> void func() <6:3 6:6>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsLocalVariableInLambdaCapture) {
+TEST_F(CxxParserTestSuite, FindsLocalVariableInLambdaCapture) {
   std::shared_ptr<TestStorage> client = parseCode(
       "void lambdaWrapper()\n"
       "{\n"
@@ -3283,10 +3245,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsLocalVariableInLambdaCapture) {
       "	[x]() { return 1; }();\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<3:6> <4:3 4:3>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<3:6> <4:3 4:3>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfLocalVariableInMicrosoftInlineAssemblyStatement) {
+TEST_F(CxxParserTestSuite, FindsUsageOfLocalVariableInMicrosoftInlineAssemblyStatement) {
   std::shared_ptr<TestStorage> client = parseCode(
       "void foo()\n"
       "{\n"
@@ -3299,12 +3261,12 @@ TEST_F(CxxParserTestSuite, cxxParserFindsUsageOfLocalVariableInMicrosoftInlineAs
       "}\n",
       {L"--target=i686-pc-windows-msvc"});
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<3:6> <6:11 6:11>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<3:6> <6:11 6:11>"));
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<3:6> <7:6 7:6>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<3:6> <7:6 7:6>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTemplateArgumentOfUnresolvedLookupExpression) {
+TEST_F(CxxParserTestSuite, FindsTemplateArgumentOfUnresolvedLookupExpression) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "void a()\n"
@@ -3317,13 +3279,13 @@ TEST_F(CxxParserTestSuite, cxxParserFindsTemplateArgumentOfUnresolvedLookupExpre
       "	a<MessageType>();\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<6:20> <9:4 9:14>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<6:20> <9:4 9:14>"));
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // test finding symbol locations
 
-TEST_F(CxxParserTestSuite, cxxParserFindsCorrectLocationOfExplicitConstructorDefinedInNamespace) {
+TEST_F(CxxParserTestSuite, FindsCorrectLocationOfExplicitConstructorDefinedInNamespace) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace n\n"
       "{\n"
@@ -3338,30 +3300,30 @@ TEST_F(CxxParserTestSuite, cxxParserFindsCorrectLocationOfExplicitConstructorDef
       "	n::App a = n::App(2);\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"int main() -> void n::App::App(int) <11:16 11:18>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"int main() -> void n::App::App(int) <11:16 11:18>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMacroArgumentLocationForFieldDefinitionWithNamePassedAsArgumentToMacro) {
+TEST_F(CxxParserTestSuite, FindsMacroArgumentLocationForFieldDefinitionWithNamePassedAsArgumentToMacro) {
   std::shared_ptr<TestStorage> client = parseCode(
       "#define DEF_INT_FIELD(name) int name;\n"
       "class A {\n"
       "	DEF_INT_FIELD(m_value)\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->fields, L"private int A::m_value <3:16 3:22>"));
+  EXPECT_THAT(client->fields, testing::Contains(L"private int A::m_value <3:16 3:22>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMacroUsageLocationForFieldDefinitionWithNamePartiallyPassedAsArgumentToMacro) {
+TEST_F(CxxParserTestSuite, FindsMacroUsageLocationForFieldDefinitionWithNamePartiallyPassedAsArgumentToMacro) {
   std::shared_ptr<TestStorage> client = parseCode(
       "#define DEF_INT_FIELD(name) int m_##name;\n"
       "class A {\n"
       "	DEF_INT_FIELD(value)\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->fields, L"private int A::m_value <3:2 3:14>"));
+  EXPECT_THAT(client->fields, testing::Contains(L"private int A::m_value <3:2 3:14>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMacroArgumentLocationForFunctionCallInCodePassedAsArgumentToMacro) {
+TEST_F(CxxParserTestSuite, FindsMacroArgumentLocationForFunctionCallInCodePassedAsArgumentToMacro) {
   std::shared_ptr<TestStorage> client = parseCode(
       "#define DEF_INT_FIELD(name, init) int name = init;\n"
       "int foo() { return 5; }\n"
@@ -3369,10 +3331,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsMacroArgumentLocationForFunctionCallInC
       "	DEF_INT_FIELD(m_value, foo())\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"int A::m_value -> int foo() <4:25 4:27>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"int A::m_value -> int foo() <4:25 4:27>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsMacroUsageLocationForFunctionCallInCodeOfMacroBody) {
+TEST_F(CxxParserTestSuite, FindsMacroUsageLocationForFunctionCallInCodeOfMacroBody) {
   std::shared_ptr<TestStorage> client = parseCode(
       "int foo() { return 5; }\n"
       "#define DEF_INT_FIELD(name) int name = foo();\n"
@@ -3380,20 +3342,20 @@ TEST_F(CxxParserTestSuite, cxxParserFindsMacroUsageLocationForFunctionCallInCode
       "	DEF_INT_FIELD(m_value)\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"int A::m_value -> int foo() <4:2 4:14>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"int A::m_value -> int foo() <4:2 4:14>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsTypeTemplateArgumentOfStaticCastExpression) {
+TEST_F(CxxParserTestSuite, FindsTypeTemplateArgumentOfStaticCastExpression) {
   std::shared_ptr<TestStorage> client = parseCode(
       "int main()\n"
       "{\n"
       "	return static_cast<int>(4.0f);"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->typeUses, L"int main() -> int <3:21 3:23>"));
+  EXPECT_THAT(client->typeUses, testing::Contains(L"int main() -> int <3:21 3:23>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsImplicitConstructorCallInInitialization) {
+TEST_F(CxxParserTestSuite, FindsImplicitConstructorCallInInitialization) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A\n"
       "{\n"
@@ -3404,10 +3366,10 @@ TEST_F(CxxParserTestSuite, cxxParserFindsImplicitConstructorCallInInitialization
       "	A m_a;\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->calls, L"void B::B() -> void A::A() <6:2 6:2>"));
+  EXPECT_THAT(client->calls, testing::Contains(L"void B::B() -> void A::A() <6:2 6:2>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserParsesMultipleFiles) {
+TEST_F(CxxParserTestSuite, ParsesMultipleFiles) {
   const std::set<FilePath> indexedPaths = {FilePath(L"data/CxxParserTestSuite/")};
   const std::set<FilePathFilter> excludeFilters;
   const std::set<FilePathFilter> includeFilters;
@@ -3420,7 +3382,7 @@ TEST_F(CxxParserTestSuite, cxxParserParsesMultipleFiles) {
       excludeFilters,
       includeFilters,
       workingDirectory,
-      std::vector<std::wstring>{L"--target=x86_64-pc-windows-msvc", L"-std=c++1z", sourceFilePath.wstr()});
+      std::vector<std::wstring>{L"--target=x86_64-pc-windows-msvc", L"-std=c++17", sourceFilePath.wstr()});
 
   std::shared_ptr<IntermediateStorage> storage = std::make_shared<IntermediateStorage>();
   CxxParser parser(std::make_shared<ParserClientImpl>(storage.get()),
@@ -3431,59 +3393,59 @@ TEST_F(CxxParserTestSuite, cxxParserParsesMultipleFiles) {
 
   std::shared_ptr<TestStorage> testStorage = TestStorage::create(storage);
 
-  EXPECT_TRUE(testStorage->errors.size() == 0);
+  EXPECT_EQ(testStorage->errors.size(), 0);
 
-  EXPECT_TRUE(testStorage->typedefs.size() == 1);
-  EXPECT_TRUE(testStorage->classes.size() == 4);
-  EXPECT_TRUE(testStorage->enums.size() == 1);
-  EXPECT_TRUE(testStorage->enumConstants.size() == 2);
-  EXPECT_TRUE(testStorage->functions.size() == 2);
-  EXPECT_TRUE(testStorage->fields.size() == 4);
-  EXPECT_TRUE(testStorage->globalVariables.size() == 2);
-  EXPECT_TRUE(testStorage->methods.size() == 15);
-  EXPECT_TRUE(testStorage->namespaces.size() == 2);
-  EXPECT_TRUE(testStorage->structs.size() == 1);
+  EXPECT_EQ(testStorage->typedefs.size(), 1);
+  EXPECT_EQ(testStorage->classes.size(), 4);
+  EXPECT_EQ(testStorage->enums.size(), 1);
+  EXPECT_EQ(testStorage->enumConstants.size(), 2);
+  EXPECT_EQ(testStorage->functions.size(), 2);
+  EXPECT_EQ(testStorage->fields.size(), 4);
+  EXPECT_EQ(testStorage->globalVariables.size(), 2);
+  EXPECT_EQ(testStorage->methods.size(), 15);
+  EXPECT_EQ(testStorage->namespaces.size(), 2);
+  EXPECT_EQ(testStorage->structs.size(), 1);
 
-  EXPECT_TRUE(testStorage->inheritances.size() == 1);
-  EXPECT_TRUE(testStorage->calls.size() == 3);
-  EXPECT_TRUE(testStorage->usages.size() == 3);
-  EXPECT_TRUE(testStorage->typeUses.size() == 16);
+  EXPECT_EQ(testStorage->inheritances.size(), 1);
+  EXPECT_EQ(testStorage->calls.size(), 3);
+  EXPECT_EQ(testStorage->usages.size(), 3);
+  EXPECT_EQ(testStorage->typeUses.size(), 16);
 
-  EXPECT_TRUE(testStorage->files.size() == 2);
-  EXPECT_TRUE(testStorage->includes.size() == 1);
+  EXPECT_EQ(testStorage->files.size(), 2);
+  EXPECT_EQ(testStorage->includes.size(), 1);
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsBracesOfClassDecl) {
+TEST_F(CxxParserTestSuite, FindsBracesOfClassDecl) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class App\n"
       "{\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<2:1> <2:1 2:1>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<2:1> <3:1 3:1>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<2:1> <2:1 2:1>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<2:1> <3:1 3:1>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsBracesOfNamespaceDecl) {
+TEST_F(CxxParserTestSuite, FindsBracesOfNamespaceDecl) {
   std::shared_ptr<TestStorage> client = parseCode(
       "namespace n\n"
       "{\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<2:1> <2:1 2:1>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<2:1> <3:1 3:1>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<2:1> <2:1 2:1>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<2:1> <3:1 3:1>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsBracesOfFunctionDecl) {
+TEST_F(CxxParserTestSuite, FindsBracesOfFunctionDecl) {
   std::shared_ptr<TestStorage> client = parseCode(
       "int main()\n"
       "{\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<2:1> <2:1 2:1>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<2:1> <3:1 3:1>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<2:1> <2:1 2:1>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<2:1> <3:1 3:1>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsBracesOfMethodDecl) {
+TEST_F(CxxParserTestSuite, FindsBracesOfMethodDecl) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class App\n"
       "{\n"
@@ -3491,31 +3453,31 @@ TEST_F(CxxParserTestSuite, cxxParserFindsBracesOfMethodDecl) {
       "	App(int i) {}\n"
       "};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<4:13> <4:13 4:13>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<4:13> <4:14 4:14>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<4:13> <4:13 4:13>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<4:13> <4:14 4:14>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsBracesOfInitList) {
+TEST_F(CxxParserTestSuite, FindsBracesOfInitList) {
   std::shared_ptr<TestStorage> client = parseCode(
       "int a = 0;\n"
       "int b[] = {a};\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<2:11> <2:11 2:11>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<2:11> <2:13 2:13>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<2:11> <2:11 2:11>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<2:11> <2:13 2:13>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsBracesOfLambda) {
+TEST_F(CxxParserTestSuite, FindsBracesOfLambda) {
   std::shared_ptr<TestStorage> client = parseCode(
       "void lambdaCaller()\n"
       "{\n"
       "	[](){}();\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<3:6> <3:6 3:6>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<3:6> <3:7 3:7>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<3:6> <3:6 3:6>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<3:6> <3:7 3:7>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsBracesOfAsmStmt) {
+TEST_F(CxxParserTestSuite, FindsBracesOfAsmStmt) {
   std::shared_ptr<TestStorage> client = parseCode(
       "void foo()\n"
       "{\n"
@@ -3526,11 +3488,11 @@ TEST_F(CxxParserTestSuite, cxxParserFindsBracesOfAsmStmt) {
       "}\n",
       {L"--target=i686-pc-windows-msvc"});
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<4:2> <4:2 4:2>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<4:2> <6:2 6:2>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<4:2> <4:2 4:2>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<4:2> <6:2 6:2>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsNoDuplicateBracesOfTemplateClassAndMethodDecl) {
+TEST_F(CxxParserTestSuite, FindsNoDuplicateBracesOfTemplateClassAndMethodDecl) {
   std::shared_ptr<TestStorage> client = parseCode(
       "template <typename T>\n"
       "class App\n"
@@ -3544,11 +3506,11 @@ TEST_F(CxxParserTestSuite, cxxParserFindsNoDuplicateBracesOfTemplateClassAndMeth
       "	return 0;\n"
       "}\n");
 
-  EXPECT_TRUE(client->localSymbols.size() == 9);
+  EXPECT_EQ(client->localSymbols.size(), 9);
   ;    // 8 braces + 1 template parameter
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsBracesWithClosingBracketInMacro) {
+TEST_F(CxxParserTestSuite, FindsBracesWithClosingBracketInMacro) {
   std::shared_ptr<TestStorage> client = parseCode(
       "\n"
       "namespace constants\n"
@@ -3562,9 +3524,9 @@ TEST_F(CxxParserTestSuite, cxxParserFindsBracesWithClosingBracketInMacro) {
       "CONSTANT(third, 3)\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<3:1> <3:1 3:1>"));
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<3:1> <7:2 7:2>"));
-  // TS_ASSERT(utility::containsElement<std::wstring>(client->localSymbols, L"<0:0> <11:1
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<3:1> <3:1 3:1>"));
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<3:1> <7:2 7:2>"));
+  // TS_ASSERT(utility::containsElement<std::wstring>(client->localSymbols, testing::Contains(L"<0:0> <11:1
   // 11:1>")); // unwanted sideeffect
 
   client = parseCode(
@@ -3579,13 +3541,13 @@ TEST_F(CxxParserTestSuite, cxxParserFindsBracesWithClosingBracketInMacro) {
       "CONSTANT(third, 3)\n"
       "}\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<7:1> <7:1 7:1>"));
-  // TS_ASSERT(utility::containsElement<std::wstring>(client->localSymbols, L"temp.cpp<7:1> <10:1
+  EXPECT_THAT(client->localSymbols, testing::Contains(L"temp.cpp<7:1> <7:1 7:1>"));
+  // TS_ASSERT(utility::containsElement<std::wstring>(client->localSymbols, testing::Contains(L"temp.cpp<7:1> <10:1
   // 10:1>")); // missing TS_ASSERT(utility::containsElement<std::wstring>(client->localSymbols,
   // L"<0:0> <10:1 10:1>")); // unwanted sideeffect
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsCorrectSignatureLocationOfConstructorWithInitializerList) {
+TEST_F(CxxParserTestSuite, FindsCorrectSignatureLocationOfConstructorWithInitializerList) {
   std::shared_ptr<TestStorage> client = parseCode(
       "class A\n"
       "{\n"
@@ -3596,52 +3558,49 @@ TEST_F(CxxParserTestSuite, cxxParserFindsCorrectSignatureLocationOfConstructorWi
       "}\n");
   ;
 
-  EXPECT_TRUE(
-      utility::containsElement<std::wstring>(client->methods, L"private void A::A(const int &) <3:2 <3:2 <3:2 3:2> 3:18> 5:2>"));
+  EXPECT_THAT(client->methods, testing::Contains(L"private void A::A(const int &) <3:2 <3:2 <3:2 3:2> 3:18> 5:2>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserCatchesError) {
+TEST_F(CxxParserTestSuite, CatchesError) {
   std::shared_ptr<TestStorage> client = parseCode("int a = b;\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->errors, L"use of undeclared identifier \'b\' <1:9 1:9>"));
+  EXPECT_THAT(client->errors, testing::Contains(L"use of undeclared identifier \'b\' <1:9 1:9>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserCatchesErrorInForceInclude) {
+TEST_F(CxxParserTestSuite, CatchesErrorInForceInclude) {
   std::shared_ptr<TestStorage> client = parseCode("void foo() {} \n", {L"-include nothing"});
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->errors, L"' nothing' file not found <1:1 1:1>"));
+  EXPECT_THAT(client->errors, testing::Contains(L"' nothing' file not found <1:1 1:1>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsCorrectErrorLocationAfterLineDirective) {
+TEST_F(CxxParserTestSuite, FindsCorrectErrorLocationAfterLineDirective) {
   std::shared_ptr<TestStorage> client = parseCode(
       "#line 55 \"foo.hpp\"\n"
       "void foo()\n");
 
-  EXPECT_TRUE(
-      utility::containsElement<std::wstring>(client->errors, L"expected function body after function declarator <2:11 2:11>"));
+  EXPECT_THAT(client->errors, testing::Contains(L"expected function body after function declarator <2:11 2:11>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserCatchesErrorInMacroExpansion) {
+TEST_F(CxxParserTestSuite, CatchesErrorInMacroExpansion) {
   std::shared_ptr<TestStorage> client = parseCode(
       "#define MACRO_WITH_NONEXISTENT_PATH \"this_path_does_not_exist.txt\"\n"
       "#include MACRO_WITH_NONEXISTENT_PATH\n");
 
-  EXPECT_TRUE(
-      utility::containsElement<std::wstring>(client->errors, L"'this_path_does_not_exist.txt' file not found <2:10 2:10>"));
+  EXPECT_THAT(client->errors, testing::Contains(L"'this_path_does_not_exist.txt' file not found <2:10 2:10>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsLocationOfLineComment) {
+TEST_F(CxxParserTestSuite, FindsLocationOfLineComment) {
   std::shared_ptr<TestStorage> client = parseCode("// this is a line comment\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->comments, L"comment <1:1 1:26>"));
+  EXPECT_THAT(client->comments, testing::Contains(L"comment <1:1 1:26>"));
 }
 
-TEST_F(CxxParserTestSuite, cxxParserFindsLocationOfBlockComment) {
+TEST_F(CxxParserTestSuite, FindsLocationOfBlockComment) {
   std::shared_ptr<TestStorage> client = parseCode(
       "/* this is a\n"
       "block comment */\n");
 
-  EXPECT_TRUE(utility::containsElement<std::wstring>(client->comments, L"comment <1:1 2:17>"));
+  EXPECT_THAT(client->comments, testing::Contains(L"comment <1:1 2:17>"));
 }
 
 void _test_TEST() {


### PR DESCRIPTION
Inorder to support c++20 Sourcetrail needs to support clang 19. This changes support clang 19. It also compile with clang 15 too. The ifdef will be removed in the next release.

Ticket: [SOUR-90](https://sourcetrail.atlassian.net/browse/SOUR-90)

[SOUR-90]: https://sourcetrail.atlassian.net/browse/SOUR-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ