### PR TITLE
quality: package sourcetrail app for unix env

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -47,8 +47,6 @@ RUN mkdir -p "/tmp/llvm" &&                                                     
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}"                                                            \
     -DLLVM_ENABLE_PROJECTS="clang"                                                                        \
     -DLLVM_ENABLE_RTTI=ON                                                                                 \
-    -DCLANG_LINK_CLANG_DYLIB=ON                                                                           \
-    -DLLVM_LINK_LLVM_DYLIB=ON                                                                             \
     -DLLVM_TARGETS_TO_BUILD=host &&                                                                       \
     ninja -C "/tmp/llvm/build" -j"$(nproc)" &&                                                            \
     ninja -C "/tmp/llvm/build" install &&                                                                 \
@@ -89,7 +87,7 @@ RUN wget -q https://download.qt.io/archive/qt/6.8/6.8.2/single/qt-everywhere-src
 
 WORKDIR /tmp/qt-everywhere-src-6.8.2/build
 
-RUN ../configure -prefix /usr/local/qt6.8.2 -opensource -confirm-license -nomake examples -nomake tests -submodules qtbase,qt5compat,qtsvg -no-opengl -openssl-linked && \
+RUN ../configure -prefix /usr/local/qt6.8.2 -opensource -confirm-license -nomake examples -nomake tests -submodules qtbase,qt5compat,qtsvg -no-opengl -openssl-linked -static -release && \
     cmake --build . --parallel && \
     cmake --install . && \
     rm -rf /tmp/qt-everywhere-src-6.8.2 /tmp/qt-everywhere-src-6.8.2.tar.xz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,7 +384,7 @@ execute_process(COMMAND "${CMAKE_COMMAND}" "-E" "make_directory" "${CMAKE_BINARY
 create_symlink("${CMAKE_SOURCE_DIR}/bin/app/data" "${CMAKE_BINARY_DIR}/app/data")
 create_symlink("${CMAKE_SOURCE_DIR}/bin/app/user" "${CMAKE_BINARY_DIR}/app/user")
 # Install Executables ------------------------------------------------------------------------------------------------------------
-set(APPIMAGE_ROOT "usr")
+set(APPIMAGE_ROOT "")
 set(INSTALL_RUNTIME_DIR "${APPIMAGE_ROOT}/bin")
 
 install(TARGETS Sourcetrail Sourcetrail_indexer RUNTIME DESTINATION ${INSTALL_RUNTIME_DIR})
@@ -400,4 +400,17 @@ install(FILES "${CMAKE_SOURCE_DIR}/cmake/Sourcetrail.desktop" DESTINATION "${APP
 install(FILES "${CMAKE_SOURCE_DIR}/bin/app/data/gui/installer/Sourcetrail.png"
         DESTINATION "${APPIMAGE_ROOT}/share/icons/hicolor/256x256/apps")
 # Packaging ----------------------------------------------------------------------------------------------------------------------
-# TODO(SOUR-104)
+set(CPACK_PACKAGE_NAME "Sourcetrail")
+set(CPACK_PACKAGE_VERSION ${VERSION_STRING})
+set(CPACK_PACKAGE_VENDOR "Coati Software")
+set(CPACK_PACKAGE_CONTACT "eng.ahmedhussein89@gmail.com")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Interactive Source Explorer")
+set(CPACK_PACKAGE_DESCRIPTION
+    "Sourcetrail is an interactive source code explorer that helps you understand, refactor, and share C, C++, and Java code."
+)
+
+if(UNIX)
+  set(CPACK_GENERATOR "DEB;RPM;SH;TGZ")
+endif()
+
+include(CPack)


### PR DESCRIPTION
- Build llvm as a static library to be included in our package easily.
- Build needed QT modules as static libraries to be included in our package easily.
- Supported packaging of sourcetrail in unix env.
- Tested generated debian package only.

Ticket: SOUR-104