### PR TITLE
Fix link to Sourcetrail releases in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Sourcetrail is:
 
 ## Using Sourcetrail
 
-To setup Sourcetrail on your machine, you can either download the respective build for your operating system from our list of [Releases](https://github.com/CoatiSoftware/Sourcetrail/releases) and install it on your machine, or use one of the following package managers:
+To setup Sourcetrail on your machine, you can either download the respective build for your operating system from our list of [Releases](https://github.com/OpenSourceSourceTrail/Sourcetrail/releases) and install it on your machine.
 
 After your installation is complete, follow our [Quick Start Guide](DOCUMENTATION.md#getting-started) to get to know Sourcetrail.
 


### PR DESCRIPTION
The link sent me back to the original releases :)
* Also removed the bit mentioning package managers

Would love to try a windows build
Thanks for the updates!
Best regards